### PR TITLE
Stopping RQD killframe exception when frame is not running

### DIFF
--- a/rqd/rqd/rqcore.py
+++ b/rqd/rqd/rqcore.py
@@ -802,9 +802,8 @@ class RqCore:
     def getRunningFrame(self, frameId):
         try:
             return self.__cache[frameId]
-        except Exception:
-            log.info("frameId {} is not running on this"
-                     "machine".format(frameId))
+        except KeyError:
+            log.info("frameId {} is not running on this machine".format(frameId))
             return None
 
     def reportStatus(self, current=None):

--- a/rqd/rqd/rqcore.py
+++ b/rqd/rqd/rqcore.py
@@ -802,9 +802,10 @@ class RqCore:
     def getRunningFrame(self, frameId):
         try:
             return self.__cache[frameId]
-        except:
-            raise KeyError("frameId {} is not running on this"
-                           "machine".format(frameId))
+        except Exception:
+            log.info("frameId {} is not running on this"
+                     "machine".format(frameId))
+            return None
 
     def reportStatus(self, current=None):
         """Replies with hostReport"""

--- a/rqd/rqd/rqdservicers.py
+++ b/rqd/rqd/rqdservicers.py
@@ -1,6 +1,8 @@
 
 import logging as log
 
+import grpc
+
 from compiled_proto import rqd_pb2
 from compiled_proto import rqd_pb2_grpc
 
@@ -26,8 +28,15 @@ class RqdInterfaceServicer(rqd_pb2_grpc.RqdInterfaceServicer):
         """RPC call to return the frame info for the given frame id"""
         log.info("Request received: getRunningFrameStatus")
         frame = self.rqCore.getRunningFrame(request.frameId)
-        return rqd_pb2.RqdStaticGetRunningFrameStatusResponse(
-            running_frame_info=frame.runningFrameInfo())
+        if frame:
+            return rqd_pb2.RqdStaticGetRunningFrameStatusResponse(
+                running_frame_info=frame.runningFrameInfo())
+        else:
+            context.set_details(
+                "The requested frame was not found. frameId: {}".format(request.frameId))
+            context.set_code(grpc.StatusCode.NOT_FOUND)
+            return rqd_pb2.RqdStaticGetRunningFrameStatusResponse()
+
 
     def KillRunningFrame(self, request, context):
         """RPC call that kills the running frame with the given id"""

--- a/rqd/rqd/rqdservicers.py
+++ b/rqd/rqd/rqdservicers.py
@@ -42,7 +42,8 @@ class RqdInterfaceServicer(rqd_pb2_grpc.RqdInterfaceServicer):
         """RPC call that kills the running frame with the given id"""
         log.info("Request received: killRunningFrame")
         frame = self.rqCore.getRunningFrame(request.frame_id)
-        frame.kill()
+        if frame:
+            frame.kill()
         return rqd_pb2.RqdStaticKillRunningFrameResponse()
 
     def ShutdownRqdNow(self, request, context):


### PR DESCRIPTION
Issue #168 
RQD no longer throws an exception if the frame is not currently running when `killFrame` is called.