### PR TITLE
Unmonitor the job when killing it

### DIFF
--- a/cuegui/cuegui/MenuActions.py
+++ b/cuegui/cuegui/MenuActions.py
@@ -299,6 +299,7 @@ class JobActions(AbstractActions):
                                       [job.data.name for job in jobs]):
                 for job in jobs:
                     job.kill()
+                    self.unmonitor(job)
                 self._update()
 
     eatDead_info = ["Eat dead frames", None, "eat"]


### PR DESCRIPTION
Fixes Issue #162 
When killing a job in the 'Monitor Jobs' view, the job wasn't being removed from the job list. A user would have to click kill and then click unmonitor. I'm suggesting we do both these actions in the kill action.
Including @jrray in case there's a better way that this should be happening.