### PR TITLE
Add ability to use EDITOR env var as log view text editor 

### DIFF
--- a/cuegui/cuegui/Utils.py
+++ b/cuegui/cuegui/Utils.py
@@ -443,8 +443,7 @@ def popupView(file, facility=None):
     if not popupWeb(file, facility):
         from Constants import DEFAULT_EDITOR
         editor = os.getenv('EDITOR', DEFAULT_EDITOR).split()
-        JOB_LOG_CMD = QtGui.qApp.settings.value("LogEditor", editor)
-        job_log_cmd = JOB_LOG_CMD or editor
+        job_log_cmd = QtGui.qApp.settings.value("LogEditor", editor) or editor
         job_log_cmd.append(str(file))
         checkShellOut(job_log_cmd)
 

--- a/cuegui/cuegui/Utils.py
+++ b/cuegui/cuegui/Utils.py
@@ -442,10 +442,10 @@ def popupTail(file, facility=None):
 def popupView(file, facility=None):
     if not popupWeb(file, facility):
         editor_from_env = os.getenv('EDITOR')
-        if QtGui.qApp.settings.contains('LogEditor'):
-            job_log_cmd = QtGui.qApp.settings.value("LogEditor")
-        elif editor_from_env:
+        if editor_from_env:
             job_log_cmd = editor_from_env.split()
+        elif QtGui.qApp.settings.contains('LogEditor'):
+            job_log_cmd = QtGui.qApp.settings.value("LogEditor")
         else:
             job_log_cmd = DEFAULT_EDITOR.split()
         job_log_cmd.append(str(file))

--- a/cuegui/cuegui/Utils.py
+++ b/cuegui/cuegui/Utils.py
@@ -29,7 +29,7 @@ from yaml.scanner import ScannerError
 
 import Logger
 from ConfirmationDialog import ConfirmationDialog
-from Constants import DEFAULT_INI_PATH
+from Constants import DEFAULT_EDITOR, DEFAULT_INI_PATH
 from Manifest import QtCore, QtGui, opencue, QtWidgets
 
 logger = Logger.getLogger(__file__)
@@ -441,9 +441,13 @@ def popupTail(file, facility=None):
 
 def popupView(file, facility=None):
     if not popupWeb(file, facility):
-        from Constants import DEFAULT_EDITOR
-        editor = os.getenv('EDITOR', DEFAULT_EDITOR).split()
-        job_log_cmd = QtGui.qApp.settings.value("LogEditor", editor) or editor
+        editor_from_env = os.getenv('EDITOR')
+        if QtGui.qApp.settings.contains('LogEditor'):
+            job_log_cmd = QtGui.qApp.settings.value("LogEditor")
+        elif editor_from_env:
+            job_log_cmd = editor_from_env.split()
+        else:
+            job_log_cmd = DEFAULT_EDITOR.split()
         job_log_cmd.append(str(file))
         checkShellOut(job_log_cmd)
 

--- a/cuegui/cuegui/Utils.py
+++ b/cuegui/cuegui/Utils.py
@@ -266,13 +266,13 @@ def checkShellOut(cmdList):
                     code=e.returncode,
                     msg=e.output
                 )
-        showErrorMessageBox(text, title="ERROR!", detailedText=None)
+        showErrorMessageBox(text, title="ERROR Launching Log Editor!")
     except OSError, e:
         text = "Command '{cmd}' not found.\n" \
                "Please set the EDITOR environment variable to a valid " \
                "editor command. Or configure an editor command using the " \
                "Constants.DEFAULT_EDITOR variable.".format(cmd=cmdList[0])
-        showErrorMessageBox(text, title="ERROR!", detailedText=None)
+        showErrorMessageBox(text, title="ERROR Launching Log Editor!")
 
 
 def exceptionOutput(e):

--- a/cuegui/cuegui/Utils.py
+++ b/cuegui/cuegui/Utils.py
@@ -442,9 +442,7 @@ def popupTail(file, facility=None):
 def popupView(file, facility=None):
     if not popupWeb(file, facility):
         from Constants import DEFAULT_EDITOR
-        editor = os.getenv('EDITOR')
-        if editor is None:
-            editor = DEFAULT_EDITOR
+        editor = os.getenv('EDITOR', DEFAULT_EDITOR)
         JOB_LOG_CMD = str(QtGui.qApp.settings.value("LogEditor", editor))
         checkShellOut([JOB_LOG_CMD or editor, str(file)])
 

--- a/cuegui/cuegui/Utils.py
+++ b/cuegui/cuegui/Utils.py
@@ -442,9 +442,11 @@ def popupTail(file, facility=None):
 def popupView(file, facility=None):
     if not popupWeb(file, facility):
         from Constants import DEFAULT_EDITOR
-        editor = os.getenv('EDITOR', DEFAULT_EDITOR)
-        JOB_LOG_CMD = str(QtGui.qApp.settings.value("LogEditor", editor))
-        checkShellOut([JOB_LOG_CMD or editor, str(file)])
+        editor = os.getenv('EDITOR', DEFAULT_EDITOR).split()
+        JOB_LOG_CMD = QtGui.qApp.settings.value("LogEditor", editor)
+        job_log_cmd = JOB_LOG_CMD or editor
+        job_log_cmd.append(str(file))
+        checkShellOut(job_log_cmd)
 
 
 def openURL(url):


### PR DESCRIPTION
Fixes Issue #179 
Priority for the log view editor is as follows:
* EDITOR env variable
* If not defined use the Constants.DEFAULT_EDITOR variable

This change also will handle errors in launching the editor by displaying an error message to the user.