### PR TITLE
Add a CODEOWNERS file.

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+*    @bcipriano @gregdenton @jrray


### PR DESCRIPTION
This doesn't do anything yet, but the idea is that Github can use this file to enforce the guidelines laid out in our [CONTRIBUTING file](https://github.com/imageworks/OpenCue/blob/master/CONTRIBUTING.md#required-approvals) - require a certain group of people to approve a PR before it can be submitted.