### PR TITLE
Switching service dialog update to use service wrapper

### DIFF
--- a/cuegui/cuegui/ServiceDialog.py
+++ b/cuegui/cuegui/ServiceDialog.py
@@ -136,15 +136,16 @@ class ServiceForm(QtWidgets.QWidget):
             QtWidgets.QMessageBox.critical(self, "Error", "The service name must alphanumeric.")
             return
 
-        data = opencue.api.service_pb2.Service()
-        data.name = str(self.name.text())
-        data.threadable = self.threadable.isChecked()
-        data.min_cores = self.min_cores.value()
-        data.max_cores = self.max_cores.value()
-        data.min_memory = self.min_memory.value() * 1024
-        data.min_gpu = self.min_gpu.value() * 1024
+        data = opencue.wrappers.service.Service()
+        data.data.id = self.__service.id
+        data.setName(str(self.name.text()))
+        data.setThreadable(self.threadable.isChecked())
+        data.setMinCores(self.min_cores.value())
+        data.setMaxCores(self.max_cores.value())
+        data.setMinMemory(self.min_memory.value() * 1024)
+        data.setMinGpu(self.min_gpu.value() * 1024)
+        data.setTags(self._tags_w.get_tags())
 
-        data.tags.extend(self._tags_w.get_tags())
         self.saved.emit(data)
 
 
@@ -221,7 +222,7 @@ class ServiceManager(QtWidgets.QWidget):
             else:
                 opencue.api.createService(data)
         else:
-            self.__selected.update(data)
+            data.update()
 
         self.refresh()
         self.__new_service = False

--- a/cuesubmit/cuesubmit/Submission.py
+++ b/cuesubmit/cuesubmit/Submission.py
@@ -57,6 +57,8 @@ def buildLayer(layerData, command):
     """
     layer = Shell(layerData.name, command=command.split(), chunk=layerData.chunk,
                   threads=float(layerData.cores), range=str(layerData.layerRange))
+    if layerData.services:
+        layer.set_service(layerData.services[0])
     if layerData.dependType and layerData.dependsOn:
         if layerData.dependType == 'Layer':
             layer.depend_all(layerData.dependsOn)


### PR DESCRIPTION
Related to issue #183.
The service dialog was still using the raw grpc object for the update method. I've switched this to use the api wrapper instead.
Also, the submission tool wasn't correctly setting the service. This has been fixed in `cuesubmit.Submission.py`.
