### PR TITLE
Clear the frames list in the host report before each report is generated

### DIFF
--- a/pycue/opencue/wrappers/host.py
+++ b/pycue/opencue/wrappers/host.py
@@ -59,7 +59,7 @@ class Host(object):
         """
         response = self.stub.GetProcs(host_pb2.HostGetProcsRequest(host=self.data),
                                       timeout=Cuebot.Timeout)
-        return [proc.Proc(p) for p in response.procs]
+        return [proc.Proc(p) for p in response.procs.procs]
 
     def getRenderPartitions(self):
         """Returns a list of render partitions associated with this host

--- a/rqd/rqd/rqmachine.py
+++ b/rqd/rqd/rqmachine.py
@@ -592,6 +592,7 @@ class Machine:
         """Updates and returns the hostReport struct"""
         self.__hostReport.host.CopyFrom(self.getHostInfo())
 
+        self.__hostReport.ClearField('frames')
         for frameKey in self.__rqCore.getFrameKeys():
             try:
                 info = self.__rqCore.getFrame(frameKey).runningFrameInfo()


### PR DESCRIPTION
Ensure that the frames list is empty before generating frame info for host report.