### PR TITLE
Configure cuebot logs to write WARN and ERROR messages to stdout

### DIFF
--- a/cuebot/src/main/resources/log4j.properties
+++ b/cuebot/src/main/resources/log4j.properties
@@ -7,13 +7,17 @@
 # Logs Application wide INFO messages / Tomcat messges
 ###############################################################
 
-log4j.rootLogger=INFO, STDOUT
-log4j.appender.STDOUT=org.apache.log4j.RollingFileAppender 
-log4j.appender.STDOUT.File=logs/spcue.log 
-log4j.appender.STDOUT.MaxFileSize=10MB 
-log4j.appender.STDOUT.MaxBackupIndex=10 
-log4j.appender.STDOUT.layout=org.apache.log4j.PatternLayout 
+log4j.rootLogger=INFO, STDOUT, FILE
+log4j.appender.STDOUT=org.apache.log4j.ConsoleAppender
+log4j.appender.STDOUT.Threshold=WARN
+log4j.appender.STDOUT.layout=org.apache.log4j.PatternLayout
 log4j.appender.STDOUT.layout.ConversionPattern=%d %p %t %c - %m%n
+log4j.appender.FILE=org.apache.log4j.RollingFileAppender
+log4j.appender.FILE.File=logs/spcue.log
+log4j.appender.FILE.MaxFileSize=10MB
+log4j.appender.FILE.MaxBackupIndex=10
+log4j.appender.FILE.layout=org.apache.log4j.PatternLayout
+log4j.appender.FILE.layout.ConversionPattern=%d %p %t %c - %m%n
 
 log4j.category.API=INFO, API
 log4j.additivity.API=false


### PR DESCRIPTION
This change allows for the cuebot logs to be visible from `docker logs`, full logs are still written to logs/spcue.log.