### PR TITLE
Cuebot: fix image path to clean up missing png errors at startup.

### DIFF
--- a/cuebot/src/main/java/com/imageworks/spcue/service/EmailSupport.java
+++ b/cuebot/src/main/java/com/imageworks/spcue/service/EmailSupport.java
@@ -109,7 +109,7 @@ public class EmailSupport {
         ByteArrayOutputStream os = null;
         try {
             // Try loading as classpath resource
-            is = EmailSupport.class.getResourceAsStream("/resources/" + path);
+            is = EmailSupport.class.getResourceAsStream("/public/" + path);
 
             // Try loading as file (sbt-pack layout)
             if (is == null) {


### PR DESCRIPTION
The images used by EmailSupport were not being found in the jar due to the incorrect path.
Correcting this to cleanup the error messages we see at cuebot startup.