### PR TITLE
Add interceptor to do access logging and global exception passing

### DIFF
--- a/cuebot/src/main/java/com/imageworks/common/spring/remoting/CueServerInterceptor.java
+++ b/cuebot/src/main/java/com/imageworks/common/spring/remoting/CueServerInterceptor.java
@@ -32,7 +32,7 @@ public class CueServerInterceptor implements ServerInterceptor {
                 } catch (Exception e) {
                     logger.error("Caught an unexpected error.", e);
                     serverCall.close(Status.INTERNAL
-                            .withCause (e)
+                            .withCause(e)
                             .withDescription(e.toString() + "\n" + e.getMessage()),
                             new Metadata());
                 }

--- a/cuebot/src/main/java/com/imageworks/common/spring/remoting/CueServerInterceptor.java
+++ b/cuebot/src/main/java/com/imageworks/common/spring/remoting/CueServerInterceptor.java
@@ -1,0 +1,48 @@
+package com.imageworks.common.spring.remoting;
+
+import io.grpc.ForwardingServerCallListener.SimpleForwardingServerCallListener;
+import io.grpc.Grpc;
+import io.grpc.Metadata;
+import io.grpc.ServerCall;
+import io.grpc.ServerCallHandler;
+import io.grpc.ServerInterceptor;
+import io.grpc.Status;
+import org.apache.log4j.Logger;
+
+
+public class CueServerInterceptor implements ServerInterceptor {
+
+    private static final Logger logger = Logger.getLogger(CueServerInterceptor.class);
+    private static final Logger accessLogger = Logger.getLogger("API");
+
+    @Override
+    public <ReqT, RespT> ServerCall.Listener<ReqT> interceptCall(
+            ServerCall<ReqT, RespT> serverCall, Metadata metadata,
+            ServerCallHandler<ReqT, RespT> serverCallHandler) {
+        accessLogger.info("gRPC [" +
+                serverCall.getAttributes().get(Grpc.TRANSPORT_ATTR_REMOTE_ADDR) +
+                "]: " + serverCall.getMethodDescriptor().getFullMethodName());
+
+        ServerCall.Listener<ReqT> delegate = serverCallHandler.startCall(serverCall, metadata);
+        return new SimpleForwardingServerCallListener<ReqT>(delegate) {
+            @Override
+            public void onHalfClose() {
+                try {
+                    super.onHalfClose();
+                } catch (Exception e) {
+                    logger.error("Caught an unexpected error.", e);
+                    serverCall.close(Status.INTERNAL
+                            .withCause (e)
+                            .withDescription(e.toString() + "\n" + e.getMessage()),
+                            new Metadata());
+                }
+            }
+
+            @Override
+            public void onMessage(ReqT request) {
+                accessLogger.info("Request Data: " + request);
+                super.onMessage(request);
+            }
+        };
+    }
+}

--- a/cuebot/src/main/java/com/imageworks/common/spring/remoting/GrpcServer.java
+++ b/cuebot/src/main/java/com/imageworks/common/spring/remoting/GrpcServer.java
@@ -93,6 +93,7 @@ public class GrpcServer implements ApplicationContextAware {
                 .addService(applicationContext.getBean("manageShow", ManageShow.class))
                 .addService(applicationContext.getBean("manageSubscription", ManageSubscription.class))
                 .addService(applicationContext.getBean("manageTask", ManageTask.class))
+                .intercept(new CueServerInterceptor())
                 .build();
         server.start();
         logger.info("gRPC server started on " + this.name + " at port " + this.port + " !");

--- a/pycue/opencue/util.py
+++ b/pycue/opencue/util.py
@@ -41,13 +41,13 @@ def grpcExceptionParser(grpcFunc):
             if code == grpc.StatusCode.NOT_FOUND:
                 raise exception.EntityNotFoundException("Object does not exist. {}".format(details))
             elif code == grpc.StatusCode.ALREADY_EXISTS:
-                raise exception.EntityAlreadyExistsException("Object already exists.{}"
+                raise exception.EntityAlreadyExistsException("Object already exists. {}"
                                                              .format(details))
             elif code == grpc.StatusCode.DEADLINE_EXCEEDED:
-                raise exception.DeadlineExceededException("Request deadline exceeded.{}"
+                raise exception.DeadlineExceededException("Request deadline exceeded. {}"
                                                           .format(details))
             elif code == grpc.StatusCode.INTERNAL:
-                raise exception.CueInternalErrorException("Server caught an internal exception.{}"
+                raise exception.CueInternalErrorException("Server caught an internal exception. {}"
                                                           .format(details))
             else:
                 raise exception.CueException("Encountered a server error. {code} : {details}"


### PR DESCRIPTION
Issue #59 
Adding a global server interceptor that takes care of access logging and passes back useful exceptions to the clients. This assumes all clients are trusted.

Format for access logs:
"""
gRPC [/127.0.0.1:33070]: job.JobInterface/GetJob
Request Data: id: "testjob"
"""