### PR TITLE
Make job log directory location be configurable in opencue.properties

### DIFF
--- a/cuebot/src/main/java/com/imageworks/spcue/util/JobLogUtil.java
+++ b/cuebot/src/main/java/com/imageworks/spcue/util/JobLogUtil.java
@@ -20,9 +20,16 @@
 package com.imageworks.spcue.util;
 
 import java.io.File;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
 import com.imageworks.spcue.JobDetail;
 
+@Component
 public class JobLogUtil {
+
+    private static String jobLogRootDir;
 
     public static boolean createJobLogDirectory(String path) {
         File f = new File(path);
@@ -32,24 +39,41 @@ public class JobLogUtil {
     }
 
     public static boolean shotLogDirectoryExists(String show, String shot) {
-        return new File(String.format("/shots/%s/%s/logs", show, shot)).exists();
+        return new File(getJobLogDir(show, shot)).exists();
     }
 
     public static boolean jobLogDirectoryExists(JobDetail job) {
         return new File(job.logDir).exists();
     }
 
+    public static String getJobLogDir(String show, String shot) {
+        StringBuilder sb = new StringBuilder(512);
+        sb.append(jobLogRootDir);
+        sb.append("/");
+        sb.append(show);
+        sb.append("/");
+        sb.append(shot);
+        sb.append("/logs");
+        return sb.toString();
+    }
+
     public static String getJobLogPath(JobDetail job) {
         StringBuilder sb = new StringBuilder(512);
-        sb.append("/shots/");
-        sb.append(job.showName);
+        sb.append(getJobLogDir(job.showName, job.shot));
         sb.append("/");
-        sb.append(job.shot);
-        sb.append("/logs/");
         sb.append(job.name);
         sb.append("--");
         sb.append(job.id);
         return sb.toString();
+    }
+
+    public static String getJobLogRootDir() {
+        return jobLogRootDir;
+    }
+
+    @Value("${log.frameLogDirRoot}")
+    public void setJobLogRootDir(String logRootDir) {
+        jobLogRootDir = logRootDir;
     }
 }
 

--- a/cuebot/src/main/java/com/imageworks/spcue/util/JobLogUtil.java
+++ b/cuebot/src/main/java/com/imageworks/spcue/util/JobLogUtil.java
@@ -29,7 +29,7 @@ import com.imageworks.spcue.JobDetail;
 @Component
 public class JobLogUtil {
 
-    private static String jobLogRootDir;
+    public static String jobLogRootDir;
 
     public static boolean createJobLogDirectory(String path) {
         File f = new File(path);

--- a/cuebot/src/main/resources/opencue.properties
+++ b/cuebot/src/main/resources/opencue.properties
@@ -28,3 +28,6 @@ grpc.rqd_server_port=${CUEBOT_GRPC_RQD_SERVER_PORT:8444}
 # Whether or not to enable publishing to a messaging topic.
 # Set to a boolean value. See com/imageworks/spcue/services/JmsMover.java.
 messaging.enabled=false
+
+# Root directory for which logs will be stored. See com/imageworks/spcue/util/JobLogUtil.java.
+log.frameLogDirRoot=/shots

--- a/cuebot/src/test/java/com/imageworks/spcue/test/util/JobLogUtilTests.java
+++ b/cuebot/src/test/java/com/imageworks/spcue/test/util/JobLogUtilTests.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2018 Sony Pictures Imageworks Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+
+package com.imageworks.spcue.test.util;
+
+import junit.framework.TestCase;
+import org.junit.Before;
+
+import com.imageworks.spcue.JobDetail;
+import com.imageworks.spcue.util.JobLogUtil;
+
+public class JobLogUtilTests extends TestCase {
+
+    @Before
+    public void setUp() {
+        JobLogUtil.jobLogRootDir = "/shots";
+    }
+
+    public void testGetJobLogRootDir() {
+        assertEquals(JobLogUtil.getJobLogRootDir(), "/shots");
+    }
+
+    public void testGetJobLogDir() {
+        assertEquals(JobLogUtil.getJobLogDir("show", "shot"), "/shots/show/shot/logs");
+    }
+
+    public void testGetJobLogPath() {
+        JobDetail jobDetail = new JobDetail();
+        jobDetail.id = "id";
+        jobDetail.name = "name";
+        jobDetail.showName = "show";
+        jobDetail.shot = "shot";
+        assertEquals(JobLogUtil.getJobLogPath(jobDetail), "/shots/show/shot/logs/name--id");
+    }
+}
+


### PR DESCRIPTION
Issue #180 
Move configuration of the job log directory to the properties files, allowing log directory location to be configured in the file or set on the command line.