### PR TITLE
Randomize order of configured cuebot hosts when establishing a channel

### DIFF
--- a/pycue/opencue/cuebot.py
+++ b/pycue/opencue/cuebot.py
@@ -149,9 +149,9 @@ class Cuebot(object):
     def setChannel():
         """Sets the gRPC channel connection"""
         # gRPC must specify a single host. Randomize host list to balance load accross cuebots.
-        cuebot_hosts = list(Cuebot.Hosts)
-        shuffle(cuebot_hosts)
-        for host in cuebot_hosts:
+        hosts = list(Cuebot.Hosts)
+        shuffle(hosts)
+        for host in hosts:
             if ':' in host:
                 connect_str = host
             else:

--- a/pycue/opencue/cuebot.py
+++ b/pycue/opencue/cuebot.py
@@ -18,6 +18,7 @@ from __future__ import division
 from __future__ import absolute_import
 
 from builtins import object
+from random import shuffle
 import atexit
 import grpc
 import logging
@@ -147,8 +148,10 @@ class Cuebot(object):
     @staticmethod
     def setChannel():
         """Sets the gRPC channel connection"""
-        # gRPC must specify a single host.
-        for host in Cuebot.Hosts:
+        # gRPC must specify a single host. Randomize host list to balance load accross cuebots.
+        cuebot_hosts = list(Cuebot.Hosts)
+        shuffle(cuebot_hosts)
+        for host in cuebot_hosts:
             if ':' in host:
                 connect_str = host
             else:
@@ -157,6 +160,9 @@ class Cuebot(object):
             # TODO(bcipriano) Configure gRPC TLS. (Issue #150)
             try:
                 Cuebot.RpcChannel = grpc.insecure_channel(connect_str)
+                # Test the connection
+                Cuebot.getStub('cue').GetSystemStats(
+                    cue_pb2.CueGetSystemStatsRequest(), timeout=Cuebot.Timeout)
             except Exception:
                 logger.warning('Could not establish grpc channel with {}.'.format(connect_str))
                 continue

--- a/rqd/rqd/rqnetwork.py
+++ b/rqd/rqd/rqnetwork.py
@@ -53,11 +53,13 @@ Everything can throw SpiIce.SpiIceException
 
 
 from concurrent import futures
-import os
-import time
+from random import shuffle
+import atexit
 import logging as log
+import os
 import platform
 import subprocess
+import time
 
 import grpc
 
@@ -188,21 +190,35 @@ class GrpcServer(object):
 
 
 class Network(object):
-    """Handles ice communication"""
+    """Handles gRPC communication"""
     def __init__(self, rqCore):
         """Network class initialization"""
         self.rqCore = rqCore
         self.grpcServer = None
+        self.channel = None
 
     def start_grpc(self):
         self.grpcServer = GrpcServer(self.rqCore)
         self.grpcServer.serveForever()
 
+    def closeChannel(self):
+        self.channel.close()
+        del self.channel
+        self.channel = None
+
+    def __getChannel(self):
+        if self.channel is None:
+            cuebots = rqconstants.CUEBOT_HOSTNAME.split()
+            shuffle(cuebots)
+            for cuebotHostname in cuebots:
+                self.channel = grpc.insecure_channel('%s:%s' % (cuebotHostname,
+                                                                rqconstants.CUEBOT_GRPC_PORT))
+            atexit.register(self.closeChannel)
+
     def __getReportStub(self):
         # TODO(bcipriano) Add support for the facility nameserver or drop this concept? (Issue #152)
-        cuebotHostname = rqconstants.CUEBOT_HOSTNAME.split()[0]
-        channel = grpc.insecure_channel('%s:%s' % (cuebotHostname, rqconstants.CUEBOT_GRPC_PORT))
-        return report_pb2_grpc.RqdReportInterfaceStub(channel)
+        self.__getChannel()
+        return report_pb2_grpc.RqdReportInterfaceStub(self.channel)
 
     def reportRqdStartup(self, report):
         """Wraps the ability to send a startup report to rqd via grpc"""

--- a/rqd/rqd/rqnetwork.py
+++ b/rqd/rqd/rqnetwork.py
@@ -207,6 +207,7 @@ class Network(object):
         self.channel = None
 
     def __getChannel(self):
+        # TODO(bcipriano) Add support for the facility nameserver or drop this concept? (Issue #152)
         if self.channel is None:
             cuebots = rqconstants.CUEBOT_HOSTNAME.split()
             shuffle(cuebots)
@@ -216,7 +217,6 @@ class Network(object):
             atexit.register(self.closeChannel)
 
     def __getReportStub(self):
-        # TODO(bcipriano) Add support for the facility nameserver or drop this concept? (Issue #152)
         self.__getChannel()
         return report_pb2_grpc.RqdReportInterfaceStub(self.channel)
 


### PR DESCRIPTION
Issue #229 
Randomize the order of selected cuebots for pycue and rqd.