### PR TITLE
Adding ability to override constants with config values for cuesubmit

### DIFF
--- a/cuesubmit/cuesubmit/Config.py
+++ b/cuesubmit/cuesubmit/Config.py
@@ -32,7 +32,7 @@ def getConfigValues():
             try:
                 configData = yaml.load(data)
             except yaml.YAMLError:
-                raise CuesubmitConfigError("Could not load yaml file: {}. Please check it's "
+                raise CuesubmitConfigError("Could not load yaml file: {}. Please check its "
                                            "formatting".format(configFile))
     return configData
 

--- a/cuesubmit/cuesubmit/Config.py
+++ b/cuesubmit/cuesubmit/Config.py
@@ -1,0 +1,42 @@
+#  Copyright (c) 2018 Sony Pictures Imageworks Inc.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import os
+import yaml
+
+"""
+Overwrite Constant.py values with a yaml config file, with it's path specified with the
+"CUESUBMIT_CONFIG_FILE" environment variable. An example config file is contained in the
+top level cuesubmit folder.
+"""
+
+CONFIG_FILE_ENV_VAR = 'CUESUBMIT_CONFIG_FILE'
+
+
+def getConfigValues():
+    configData = {}
+    configFile = os.environ.get(CONFIG_FILE_ENV_VAR)
+    if configFile and os.path.exists(configFile):
+        with open(configFile, 'r') as data:
+            try:
+                configData = yaml.load(data)
+            except yaml.YAMLError:
+                raise CuesubmitConfigError("Could not load yaml file: {}. Please check it's "
+                                           "formatting".format(configFile))
+    return configData
+
+
+class CuesubmitConfigError(Exception):
+    """Thrown when an error occurs reading the config file."""
+    pass

--- a/cuesubmit/cuesubmit/Constants.py
+++ b/cuesubmit/cuesubmit/Constants.py
@@ -15,15 +15,19 @@
 
 import os
 
-UI_NAME = 'OPENCUEMAYA'
-SUBMIT_APP_WINDOW_TITLE = 'OpenCue Submit'
+from cuesubmit import Config
+
+config = Config.getConfigValues()
 
 UP_KEY = 16777235
 DOWN_KEY = 16777237
 TAB_KEY = 16777217
 
-MAYA_RENDER_CMD = 'Render'
-NUKE_RENDER_CMD = 'nuke'
-FRAME_TOKEN = '#IFRAME#'
+UI_NAME = config.get('UI_NAME', 'OPENCUESUBMIT')
+SUBMIT_APP_WINDOW_TITLE = config.get('SUBMIT_APP_WINDOW_TITLE', 'OpenCue Submit')
+
+MAYA_RENDER_CMD = config.get('MAYA_RENDER_CMD', 'Render')
+NUKE_RENDER_CMD = config.get('NUKE_RENDER_CMD', 'nuke')
+FRAME_TOKEN = config.get('FRAME_TOKEN', '#IFRAME#')
 
 DIR_PATH = os.path.dirname(__file__)

--- a/cuesubmit/cuesubmit_config.example.yaml
+++ b/cuesubmit/cuesubmit_config.example.yaml
@@ -1,0 +1,10 @@
+# An Example cuesubmit config file.
+# It can be placed anywhere on your filesystem and referenced with
+# the CUESUBMIT_CONFIG_FILE environment variable.
+# If this file is not found the defaults in Constants.py will be used.
+
+UI_NAME : "OPENCUESUBMIT"
+SUBMIT_APP_WINDOW_TITLE : "OpenCue Submit"
+MAYA_RENDER_CMD : "Render"
+NUKE_RENDER_CMD : "nuke"
+FRAME_TOKEN : "#IFRAME#"


### PR DESCRIPTION
Adding an optional cuesubmit config file referenced by the environment variable `CUESUBMIT_CONFIG_FILE`, if it exists the `Constants.py` reads in the values 
Issue #256