### PR TITLE
Increase max message size to 100MB

### DIFF
--- a/cuebot/src/main/java/com/imageworks/common/spring/remoting/GrpcServer.java
+++ b/cuebot/src/main/java/com/imageworks/common/spring/remoting/GrpcServer.java
@@ -43,23 +43,23 @@ public class GrpcServer implements ApplicationContextAware {
 
     private static final String DEFAULT_NAME = "CueGrpcServer";
     private static final String DEFAULT_PORT = "8443";
-    private static final int DEFAULT_MAX_MESSAGE_SIZE = 104857600;
+    private static final int DEFAULT_MAX_MESSAGE_BYTES = 104857600;
 
     private String name;
     private int port;
-    private int maxMessageSize;
+    private int maxMessageBytes;
     private Server server;
     private ApplicationContext applicationContext;
 
     public GrpcServer() {
-        this(DEFAULT_NAME, DEFAULT_PORT, new Properties(), DEFAULT_MAX_MESSAGE_SIZE);
+        this(DEFAULT_NAME, DEFAULT_PORT, new Properties(), DEFAULT_MAX_MESSAGE_BYTES);
     }
 
-    public GrpcServer(String name, String port, Properties props, Integer maxMessageSize) {
+    public GrpcServer(String name, String port, Properties props, Integer maxMessageBytes) {
         logger.info("Setting up gRPC server...");
         this.name = name;
         this.port = Integer.parseInt(port);
-        this.maxMessageSize = maxMessageSize;
+        this.maxMessageBytes = maxMessageBytes;
     }
 
     public void shutdown() {
@@ -96,7 +96,7 @@ public class GrpcServer implements ApplicationContextAware {
                 .addService(applicationContext.getBean("manageShow", ManageShow.class))
                 .addService(applicationContext.getBean("manageSubscription", ManageSubscription.class))
                 .addService(applicationContext.getBean("manageTask", ManageTask.class))
-                .maxInboundMessageSize(maxMessageSize)
+                .maxInboundMessageSize(maxMessageBytes)
                 .intercept(new CueServerInterceptor())
                 .build();
         server.start();

--- a/cuebot/src/main/java/com/imageworks/common/spring/remoting/GrpcServer.java
+++ b/cuebot/src/main/java/com/imageworks/common/spring/remoting/GrpcServer.java
@@ -93,6 +93,7 @@ public class GrpcServer implements ApplicationContextAware {
                 .addService(applicationContext.getBean("manageShow", ManageShow.class))
                 .addService(applicationContext.getBean("manageSubscription", ManageSubscription.class))
                 .addService(applicationContext.getBean("manageTask", ManageTask.class))
+                .maxInboundMessageSize(104857600)
                 .intercept(new CueServerInterceptor())
                 .build();
         server.start();

--- a/cuebot/src/main/java/com/imageworks/common/spring/remoting/GrpcServer.java
+++ b/cuebot/src/main/java/com/imageworks/common/spring/remoting/GrpcServer.java
@@ -43,20 +43,23 @@ public class GrpcServer implements ApplicationContextAware {
 
     private static final String DEFAULT_NAME = "CueGrpcServer";
     private static final String DEFAULT_PORT = "8443";
+    private static final int DEFAULT_MAX_MESSAGE_SIZE = 104857600;
 
     private String name;
     private int port;
+    private int maxMessageSize;
     private Server server;
     private ApplicationContext applicationContext;
 
     public GrpcServer() {
-        this(DEFAULT_NAME, DEFAULT_PORT, new Properties());
+        this(DEFAULT_NAME, DEFAULT_PORT, new Properties(), DEFAULT_MAX_MESSAGE_SIZE);
     }
 
-    public GrpcServer(String name, String port, Properties props) {
+    public GrpcServer(String name, String port, Properties props, Integer maxMessageSize) {
         logger.info("Setting up gRPC server...");
         this.name = name;
         this.port = Integer.parseInt(port);
+        this.maxMessageSize = maxMessageSize;
     }
 
     public void shutdown() {
@@ -93,7 +96,7 @@ public class GrpcServer implements ApplicationContextAware {
                 .addService(applicationContext.getBean("manageShow", ManageShow.class))
                 .addService(applicationContext.getBean("manageSubscription", ManageSubscription.class))
                 .addService(applicationContext.getBean("manageTask", ManageTask.class))
-                .maxInboundMessageSize(104857600)
+                .maxInboundMessageSize(maxMessageSize)
                 .intercept(new CueServerInterceptor())
                 .build();
         server.start();

--- a/cuebot/src/main/resources/conf/spring/applicationContext-grpcServer.xml
+++ b/cuebot/src/main/resources/conf/spring/applicationContext-grpcServer.xml
@@ -40,7 +40,7 @@
             </props>
         </constructor-arg>
         <constructor-arg index="3" type="java.lang.Integer">
-            <value>${grpc.max_message_size}</value>
+            <value>${grpc.max_message_bytes}</value>
         </constructor-arg>
     </bean>
 

--- a/cuebot/src/main/resources/conf/spring/applicationContext-grpcServer.xml
+++ b/cuebot/src/main/resources/conf/spring/applicationContext-grpcServer.xml
@@ -39,6 +39,9 @@
                 <prop key="cue_">com.imageworks.common</prop>
             </props>
         </constructor-arg>
+        <constructor-arg index="3" type="java.lang.Integer">
+            <value>${grpc.max_message_size}</value>
+        </constructor-arg>
     </bean>
 
 </beans>

--- a/cuebot/src/main/resources/opencue.properties
+++ b/cuebot/src/main/resources/opencue.properties
@@ -24,7 +24,7 @@ datasource.trackitDataSource.maxAge=21600000
 
 grpc.cue_port=${CUEBOT_GRPC_CUE_PORT:8443}
 grpc.rqd_server_port=${CUEBOT_GRPC_RQD_SERVER_PORT:8444}
-grpc.max_message_size=104857600
+grpc.max_message_bytes=104857600
 # Number of entries allowed in the RQD channel cache
 grpc.rqd_cache_size=500
 # RQD Channel Cache Expiration in Minutes

--- a/cuebot/src/main/resources/opencue.properties
+++ b/cuebot/src/main/resources/opencue.properties
@@ -24,6 +24,7 @@ datasource.trackitDataSource.maxAge=21600000
 
 grpc.cue_port=${CUEBOT_GRPC_CUE_PORT:8443}
 grpc.rqd_server_port=${CUEBOT_GRPC_RQD_SERVER_PORT:8444}
+grpc.max_message_size=104857600
 # Number of entries allowed in the RQD channel cache
 grpc.rqd_cache_size=500
 # RQD Channel Cache Expiration in Minutes

--- a/cuebot/src/test/resources/conf/spring/applicationContext-grpcServer.xml
+++ b/cuebot/src/test/resources/conf/spring/applicationContext-grpcServer.xml
@@ -40,7 +40,7 @@
             </props>
         </constructor-arg>
         <constructor-arg index="3" type="java.lang.Integer">
-            <value>${grpc.max_message_size}</value>
+            <value>${grpc.max_message_bytes}</value>
         </constructor-arg>
     </bean>
 

--- a/cuebot/src/test/resources/conf/spring/applicationContext-grpcServer.xml
+++ b/cuebot/src/test/resources/conf/spring/applicationContext-grpcServer.xml
@@ -32,25 +32,15 @@
             <value>cueBotGrpc</value>
         </constructor-arg>
         <constructor-arg index="1" type="java.lang.String">
-            <value>8453</value>
+            <value>${grpc.cue_port}</value>
         </constructor-arg>
         <constructor-arg index="2">
             <props>
                 <prop key="cue_">com.imageworks.common</prop>
             </props>
         </constructor-arg>
-    </bean>
-
-    <bean id="rqdGrpcServer" class="com.imageworks.common.spring.remoting.GrpcServer" init-method="start" destroy-method="shutdown">
-        <constructor-arg index="0" type="java.lang.String">
-            <value>cueBotGrpc</value>
-        </constructor-arg>
-        <constructor-arg index="1" type="java.lang.String">
-            <value>8454</value>
-        </constructor-arg>
-        <constructor-arg index="2">
-            <props>
-            </props>
+        <constructor-arg index="3" type="java.lang.Integer">
+            <value>${grpc.max_message_size}</value>
         </constructor-arg>
     </bean>
 

--- a/cuebot/src/test/resources/opencue.properties
+++ b/cuebot/src/test/resources/opencue.properties
@@ -12,7 +12,7 @@ datasource.trackitDataSource.maxAge=21600000
 
 grpc.cue_port=8453
 grpc.rqd_server_port=${CUEBOT_GRPC_RQD_SERVER_PORT:50051}
-grpc.max_message_size=104857600
+grpc.max_message_bytes=104857600
 # Number of entries allowed in the RQD channel cache
 grpc.rqd_cache_size=500
 # RQD Channel Cache Expiration in Minutes

--- a/cuebot/src/test/resources/opencue.properties
+++ b/cuebot/src/test/resources/opencue.properties
@@ -10,7 +10,9 @@ datasource.trackitDataSource.password=password
 # connection rebalancing.
 datasource.trackitDataSource.maxAge=21600000
 
+grpc.cue_port=8453
 grpc.rqd_server_port=${CUEBOT_GRPC_RQD_SERVER_PORT:50051}
+grpc.max_message_size=104857600
 # Number of entries allowed in the RQD channel cache
 grpc.rqd_cache_size=500
 # RQD Channel Cache Expiration in Minutes

--- a/pycue/opencue/cuebot.py
+++ b/pycue/opencue/cuebot.py
@@ -67,7 +67,7 @@ fcnf = os.environ.get('OPENCUE_CONF', '')
 if os.path.exists(fcnf):
     config.update(yaml.load(open(fcnf).read()))
 
-DEFAULT_MAX_MESSAGE_SIZE = 1024 ** 2 * 10
+DEFAULT_MAX_MESSAGE_BYTES = 1024 ** 2 * 10
 DEFAULT_GRPC_PORT = 8443
 
 class Cuebot(object):
@@ -153,7 +153,7 @@ class Cuebot(object):
         # gRPC must specify a single host. Randomize host list to balance load across cuebots.
         hosts = list(Cuebot.Hosts)
         shuffle(hosts)
-        maxMessageSize = config.get('cuebot.max_message_size', DEFAULT_MAX_MESSAGE_SIZE)
+        maxMessageSize = config.get('cuebot.max_message_bytes', DEFAULT_MAX_MESSAGE_BYTES)
         for host in hosts:
             if ':' in host:
                 connectStr = host

--- a/pycue/opencue/cuebot.py
+++ b/pycue/opencue/cuebot.py
@@ -67,6 +67,8 @@ fcnf = os.environ.get('OPENCUE_CONF', '')
 if os.path.exists(fcnf):
     config.update(yaml.load(open(fcnf).read()))
 
+DEFAULT_MAX_MESSAGE_SIZE = 1024 ** 2 * 10
+DEFAULT_GRPC_PORT = 8443
 
 class Cuebot(object):
     """Used to manage the connection to the Cuebot.  Normally the connection
@@ -151,20 +153,23 @@ class Cuebot(object):
         # gRPC must specify a single host. Randomize host list to balance load across cuebots.
         hosts = list(Cuebot.Hosts)
         shuffle(hosts)
+        maxMessageSize = config.get('cuebot.max_message_size', DEFAULT_MAX_MESSAGE_SIZE)
         for host in hosts:
             if ':' in host:
-                connect_str = host
+                connectStr = host
             else:
-                connect_str = '%s:%s' % (host, config.get('cuebot.grpc_port', 8443))
-            logger.debug('connecting to gRPC at %s', connect_str)
+                connectStr = '%s:%s' % (host, config.get('cuebot.grpc_port', DEFAULT_GRPC_PORT))
+            logger.debug('connecting to gRPC at %s', connectStr)
             # TODO(bcipriano) Configure gRPC TLS. (Issue #150)
             try:
-                Cuebot.RpcChannel = grpc.insecure_channel(connect_str)
+                Cuebot.RpcChannel = grpc.insecure_channel(connectStr, options=[
+                    ('grpc.max_send_message_length', maxMessageSize),
+                    ('grpc.max_receive_message_length', maxMessageSize)])
                 # Test the connection
                 Cuebot.getStub('cue').GetSystemStats(
                     cue_pb2.CueGetSystemStatsRequest(), timeout=Cuebot.Timeout)
             except Exception:
-                logger.warning('Could not establish grpc channel with {}.'.format(connect_str))
+                logger.warning('Could not establish grpc channel with {}.'.format(connectStr))
                 continue
             atexit.register(Cuebot.closeChannel)
             return None

--- a/pycue/opencue/cuebot.py
+++ b/pycue/opencue/cuebot.py
@@ -153,7 +153,7 @@ class Cuebot(object):
         # gRPC must specify a single host. Randomize host list to balance load across cuebots.
         hosts = list(Cuebot.Hosts)
         shuffle(hosts)
-        maxMessageSize = config.get('cuebot.max_message_bytes', DEFAULT_MAX_MESSAGE_BYTES)
+        maxMessageBytes = config.get('cuebot.max_message_bytes', DEFAULT_MAX_MESSAGE_BYTES)
         for host in hosts:
             if ':' in host:
                 connectStr = host
@@ -163,8 +163,8 @@ class Cuebot(object):
             # TODO(bcipriano) Configure gRPC TLS. (Issue #150)
             try:
                 Cuebot.RpcChannel = grpc.insecure_channel(connectStr, options=[
-                    ('grpc.max_send_message_length', maxMessageSize),
-                    ('grpc.max_receive_message_length', maxMessageSize)])
+                    ('grpc.max_send_message_length', maxMessageBytes),
+                    ('grpc.max_receive_message_length', maxMessageBytes)])
                 # Test the connection
                 Cuebot.getStub('cue').GetSystemStats(
                     cue_pb2.CueGetSystemStatsRequest(), timeout=Cuebot.Timeout)

--- a/pycue/opencue/default.yaml
+++ b/pycue/opencue/default.yaml
@@ -8,6 +8,7 @@ logger.level: WARNING
 cuebot.protocol: tcp
 cuebot.grpc_port: 8443
 cuebot.timeout: 10000
+cuebot.max_message_size: 104857600
 
 cuebot.facility_default: cloud
 cuebot.facility:

--- a/pycue/opencue/default.yaml
+++ b/pycue/opencue/default.yaml
@@ -8,7 +8,7 @@ logger.level: WARNING
 cuebot.protocol: tcp
 cuebot.grpc_port: 8443
 cuebot.timeout: 10000
-cuebot.max_message_size: 104857600
+cuebot.max_message_bytes: 104857600
 
 cuebot.facility_default: cloud
 cuebot.facility:


### PR DESCRIPTION
Increasing the grpc max message size to 100MB for cuebot and pycue to more closely match the original ice implementation.