### PR TITLE
getJobWhiteboard returns groups only and a list of job ids

### DIFF
--- a/cuebot/src/main/java/com/imageworks/spcue/dao/oracle/NestedWhiteboardDaoJdbc.java
+++ b/cuebot/src/main/java/com/imageworks/spcue/dao/oracle/NestedWhiteboardDaoJdbc.java
@@ -42,7 +42,6 @@ import com.imageworks.spcue.grpc.job.JobStats;
 import com.imageworks.spcue.grpc.job.NestedGroup;
 import com.imageworks.spcue.grpc.job.NestedGroupSeq;
 import com.imageworks.spcue.grpc.job.NestedJob;
-import com.imageworks.spcue.grpc.job.NestedJobSeq;
 import com.imageworks.spcue.util.Convert;
 import com.imageworks.spcue.util.CueUtil;
 
@@ -191,11 +190,8 @@ public class NestedWhiteboardDaoJdbc extends JdbcDaoSupport implements NestedWhi
                 group = groups.get(groupId);
             }
             if (rs.getString("pk_job") != null) {
-                NestedJob job = mapResultSetToJob(rs).toBuilder()
-                        .setParent(group)
-                        .build();
                 GroupStats oldStats = group.getStats();
-                JobStats jobStats = job.getStats();
+                JobStats jobStats = WhiteboardDaoJdbc.mapJobStats(rs);
                 GroupStats groupStats = GroupStats.newBuilder()
                         .setDeadFrames(oldStats.getDeadFrames() + jobStats.getDeadFrames())
                         .setRunningFrames(oldStats.getRunningFrames() + jobStats.getRunningFrames())
@@ -204,12 +200,9 @@ public class NestedWhiteboardDaoJdbc extends JdbcDaoSupport implements NestedWhi
                         .setReservedCores(oldStats.getReservedCores() + jobStats.getReservedCores())
                         .setPendingJobs(oldStats.getPendingJobs() + 1).build();
 
-                NestedJobSeq nestedJobSeq = group.getJobs().toBuilder()
-                        .addNestedJobs(job)
-                        .build();
                 group = group.toBuilder()
-                        .setJobs(nestedJobSeq)
                         .setStats(groupStats)
+                        .addJobs(rs.getString("pk_job"))
                         .build();
                 groups.put(groupId, group);
             }

--- a/cuebot/src/main/java/com/imageworks/spcue/dao/postgres/NestedWhiteboardDaoJdbc.java
+++ b/cuebot/src/main/java/com/imageworks/spcue/dao/postgres/NestedWhiteboardDaoJdbc.java
@@ -42,7 +42,6 @@ import com.imageworks.spcue.grpc.job.JobStats;
 import com.imageworks.spcue.grpc.job.NestedGroup;
 import com.imageworks.spcue.grpc.job.NestedGroupSeq;
 import com.imageworks.spcue.grpc.job.NestedJob;
-import com.imageworks.spcue.grpc.job.NestedJobSeq;
 import com.imageworks.spcue.util.Convert;
 import com.imageworks.spcue.util.CueUtil;
 
@@ -157,7 +156,6 @@ public class NestedWhiteboardDaoJdbc extends JdbcDaoSupport implements NestedWhi
 
         @Override
         public NestedGroup mapRow(ResultSet rs, int rowNum) throws SQLException {
-
             String groupId = rs.getString("pk_folder");
             NestedGroup group;
             if (!groups.containsKey(groupId)) {
@@ -191,11 +189,8 @@ public class NestedWhiteboardDaoJdbc extends JdbcDaoSupport implements NestedWhi
                 group = groups.get(groupId);
             }
             if (rs.getString("pk_job") != null) {
-                NestedJob job = mapResultSetToJob(rs).toBuilder()
-                        .setParent(group)
-                        .build();
                 GroupStats oldStats = group.getStats();
-                JobStats jobStats = job.getStats();
+                JobStats jobStats = WhiteboardDaoJdbc.mapJobStats(rs);
                 GroupStats groupStats = GroupStats.newBuilder()
                         .setDeadFrames(oldStats.getDeadFrames() + jobStats.getDeadFrames())
                         .setRunningFrames(oldStats.getRunningFrames() + jobStats.getRunningFrames())
@@ -204,12 +199,9 @@ public class NestedWhiteboardDaoJdbc extends JdbcDaoSupport implements NestedWhi
                         .setReservedCores(oldStats.getReservedCores() + jobStats.getReservedCores())
                         .setPendingJobs(oldStats.getPendingJobs() + 1).build();
 
-                NestedJobSeq nestedJobSeq = group.getJobs().toBuilder()
-                        .addNestedJobs(job)
-                        .build();
                 group = group.toBuilder()
-                        .setJobs(nestedJobSeq)
                         .setStats(groupStats)
+                        .addJobs(rs.getString("pk_job"))
                         .build();
                 groups.put(groupId, group);
             }

--- a/cuegui/cuegui/CueJobMonitorTree.py
+++ b/cuegui/cuegui/CueJobMonitorTree.py
@@ -439,16 +439,6 @@ class CueJobMonitorTree(cuegui.AbstractTreeWidget.AbstractTreeWidget):
                 else:
                     self._items[job.id()] = JobWidgetItem(job, groupItem)
 
-
-
-            # if hasattr(group.data.jobs, 'nested_jobs'):
-            #     for job in group.data.jobs.nested_jobs:
-            #         job = opencue.wrappers.job.NestedJob(job)
-            #         if job.id() in self._items:
-            #             self._items[job.id()].update(job, groupItem)
-            #         else:
-            #             self._items[job.id()] = JobWidgetItem(job, groupItem)
-
     def mouseDoubleClickEvent(self,event):
         objects = self.selectedObjects()
         if objects:

--- a/cuegui/cuegui/CueJobMonitorTree.py
+++ b/cuegui/cuegui/CueJobMonitorTree.py
@@ -83,24 +83,24 @@ class CueJobMonitorTree(cuegui.AbstractTreeWidget.AbstractTreeWidget):
                            "will appear here and all frames that become dead will\n"
                            "automatically be eaten.")
         self.addColumn("Run", 38, id=3,
-                       data=lambda job: job.data.stats.running_frames,
-                       sort=lambda job: job.data.stats.running_frames,
+                       data=lambda job: job.data.job_stats.running_frames,
+                       sort=lambda job: job.data.job_stats.running_frames,
                        tip="The number of running frames.")
         self.addColumn("Cores", 55, id=4,
-                       data=lambda job: "%.02f" % job.data.stats.reserved_cores,
-                       sort=lambda job: job.data.stats.reserved_cores,
+                       data=lambda job: "%.02f" % job.data.job_stats.reserved_cores,
+                       sort=lambda job: job.data.job_stats.reserved_cores,
                        tip="The number of reserved cores.")
         self.addColumn("Wait", 45, id=5,
-                       data=lambda job: job.data.stats.waiting_frames,
-                       sort=lambda job: job.data.stats.waiting_frames,
+                       data=lambda job: job.data.job_stats.waiting_frames,
+                       sort=lambda job: job.data.job_stats.waiting_frames,
                        tip="The number of waiting frames.")
         self.addColumn("Depend", 55, id=6,
-                       data=lambda job: job.data.stats.depend_frames,
-                       sort=lambda job: job.data.stats.depend_frames,
+                       data=lambda job: job.data.job_stats.depend_frames,
+                       sort=lambda job: job.data.job_stats.depend_frames,
                        tip="The number of dependent frames.")
         self.addColumn("Total", 50, id=7,
-                       data=lambda job: job.data.stats.total_frames,
-                       sort=lambda job: job.data.stats.total_frames,
+                       data=lambda job: job.data.job_stats.total_frames,
+                       sort=lambda job: job.data.job_stats.total_frames,
                        tip="The total number of frames.")
 #        self.addColumn("_Booking Bar", 150, id=8, default=False,
 #                       delegate=JobBookingBarDelegate)
@@ -130,8 +130,8 @@ class CueJobMonitorTree(cuegui.AbstractTreeWidget.AbstractTreeWidget):
                            "A very rough estimate of the number of HOURS:MINUTES\n"
                            "it will be before the entire job is done.")
         self.addColumn("MaxRss", 60, id=14,
-                       data=lambda job: cuegui.Utils.memoryToString(job.data.stats.max_rss),
-                       sort=lambda job: job.data.stats.max_rss,
+                       data=lambda job: cuegui.Utils.memoryToString(job.data.job_stats.max_rss),
+                       sort=lambda job: job.data.job_stats.max_rss,
                        tip="The most memory used at one time by any single frame.")
         self.addColumn("_Blank", 20, id=15,
                        tip="Spacer")
@@ -405,8 +405,8 @@ class CueJobMonitorTree(cuegui.AbstractTreeWidget.AbstractTreeWidget):
             updated.extend(map(self.__getNestedIds, group.groups.nested_groups))
 
             # If group has jobs, update them
-            for job in group.jobs.nested_jobs:
-                updated.append(job.id)
+            for jobId in group.jobs:
+                updated.append(jobId)
 
         return updated
 
@@ -432,13 +432,22 @@ class CueJobMonitorTree(cuegui.AbstractTreeWidget.AbstractTreeWidget):
             nestedGroups = [opencue.wrappers.group.NestedGroup(nestedGroup) for nestedGroup in group.data.groups.nested_groups]
             self.__processUpdateHandleNested(groupItem, nestedGroups)
 
-            if hasattr(group.data.jobs, 'nested_jobs'):
-                for job in group.data.jobs.nested_jobs:
-                    job = opencue.wrappers.job.NestedJob(job)
-                    if job.id() in self._items:
-                        self._items[job.id()].update(job, groupItem)
-                    else:
-                        self._items[job.id()] = JobWidgetItem(job, groupItem)
+            for jobId in group.data.jobs:
+                job = opencue.api.getJob(jobId)
+                if job.id() in self._items:
+                    self._items[job.id()].update(job, groupItem)
+                else:
+                    self._items[job.id()] = JobWidgetItem(job, groupItem)
+
+
+
+            # if hasattr(group.data.jobs, 'nested_jobs'):
+            #     for job in group.data.jobs.nested_jobs:
+            #         job = opencue.wrappers.job.NestedJob(job)
+            #         if job.id() in self._items:
+            #             self._items[job.id()].update(job, groupItem)
+            #         else:
+            #             self._items[job.id()] = JobWidgetItem(job, groupItem)
 
     def mouseDoubleClickEvent(self,event):
         objects = self.selectedObjects()
@@ -704,17 +713,17 @@ class JobWidgetItem(cuegui.AbstractWidgetItem.AbstractWidgetItem):
 
         elif role == QtCore.Qt.BackgroundRole:
             if col == COLUMN_MAXRSS and \
-               self.rpcObject.data.stats.max_rss > cuegui.Constants.MEMORY_WARNING_LEVEL:
+               self.rpcObject.data.job_stats.max_rss > cuegui.Constants.MEMORY_WARNING_LEVEL:
                     return self.__highMemoryColor
             if self.rpcObject.data.is_paused:
                 return self.__pausedColor
-            if self.rpcObject.data.stats.dead_frames:
+            if self.rpcObject.data.job_stats.dead_frames:
                 return self.__dyingColor
-            if not self.rpcObject.data.stats.running_frames:
-                if not self.rpcObject.data.stats.waiting_frames and \
-                   self.rpcObject.data.stats.depend_frames:
+            if not self.rpcObject.data.job_stats.running_frames:
+                if not self.rpcObject.data.job_stats.waiting_frames and \
+                   self.rpcObject.data.job_stats.depend_frames:
                     return self.__dependedColor
-                if self.rpcObject.data.stats.waiting_frames and \
+                if self.rpcObject.data.job_stats.waiting_frames and \
                    time.time() - self.rpcObject.data.start_time > 30:
                     return self.__noRunningColor
             return self.__backgroundColor
@@ -731,14 +740,14 @@ class JobWidgetItem(cuegui.AbstractWidgetItem.AbstractWidgetItem):
         elif role == QtCore.Qt.UserRole + 1:
             if "FST" not in self._cache:
                 self._cache["FST"] = set([
-                    ('WAITING', self.rpcObject.data.stats.waiting_frames),
-                    ('RUNNING', self.rpcObject.data.stats.running_frames),
-                    ('SUCCEEDED', self.rpcObject.data.stats.succeeded_frames),
+                    ('WAITING', self.rpcObject.data.job_stats.waiting_frames),
+                    ('RUNNING', self.rpcObject.data.job_stats.running_frames),
+                    ('SUCCEEDED', self.rpcObject.data.job_stats.succeeded_frames),
                     ('CHECKPOINT', 0),
                     ('SETUP', 0),
-                    ('EATEN', self.rpcObject.data.stats.eaten_frames),
-                    ('DEAD', self.rpcObject.data.stats.dead_frames),
-                    ('DEPEND', self.rpcObject.data.stats.depend_frames)
+                    ('EATEN', self.rpcObject.data.job_stats.eaten_frames),
+                    ('DEAD', self.rpcObject.data.job_stats.dead_frames),
+                    ('DEPEND', self.rpcObject.data.job_stats.depend_frames)
                 ])
             return self._cache.get("FST", cuegui.Constants.QVARIANT_NULL)
 

--- a/cuegui/cuegui/CueJobMonitorTree.py
+++ b/cuegui/cuegui/CueJobMonitorTree.py
@@ -599,8 +599,8 @@ class RootGroupWidgetItem(cuegui.AbstractWidgetItem.AbstractWidgetItem):
     def __lt__(self, other):
         """The shows are always ascending alphabetical"""
         if self.treeWidget().header().sortIndicatorOrder():
-            return other.rpcObject.name < self.rpcObject.name
-        return other.rpcObject.name > self.rpcObject.name
+            return other.rpcObject.name() < self.rpcObject.name()
+        return other.rpcObject.name() > self.rpcObject.name()
 
     def __ne__(self, other):
         return other.rpcObject != self.rpcObject
@@ -651,8 +651,8 @@ class GroupWidgetItem(cuegui.AbstractWidgetItem.AbstractWidgetItem):
     def __lt__(self, other):
         """Groups are always ascending alphabetical"""
         if self.treeWidget().header().sortIndicatorOrder():
-            return other.rpcObject.name < self.rpcObject.name
-        return other.rpcObject.name > self.rpcObject.name
+            return other.rpcObject.name() < self.rpcObject.name()
+        return other.rpcObject.name() > self.rpcObject.name()
 
     def __ne__(self, other):
         if hasattr(other, 'rpcObject'):

--- a/cuegui/cuegui/GroupDialog.py
+++ b/cuegui/cuegui/GroupDialog.py
@@ -190,7 +190,7 @@ class ModifyGroupDialog(GroupDialog):
 class NewGroupDialog(GroupDialog):
     def __init__(self, parentGroup, parent=None):
         defaults = {"title": "Create New Group",
-                    "message": "Group to be created as a child of the group %s" % parentGroup.name,
+                    "message": "Group to be created as a child of the group %s" % parentGroup.name(),
                     "name": "",
                     "department": "Unknown",
                     "defaultJobPriority": 0,

--- a/proto/job.proto
+++ b/proto/job.proto
@@ -647,7 +647,7 @@ message NestedGroup {
     int32 level = 9;
     NestedGroup parent = 10;
     NestedGroupSeq groups = 11;
-    NestedJobSeq jobs = 12;
+    repeated string jobs = 12;
     GroupStats stats = 13;
 }
 
@@ -678,10 +678,6 @@ message NestedJob {
     int32 stop_time = 19;
     NestedGroup parent = 20;
     JobStats stats = 21;
-}
-
-message NestedJobSeq {
-    repeated NestedJob nested_jobs = 1;
 }
 
 


### PR DESCRIPTION
To keep the response from getJobWhiteboard to a reasonable size, it will only return the groups and the nested job ids instead of the job objects themselves. The Job objects can be fetched in subsequent calls.