### PR TITLE
Cuegui linux style updates

### DIFF
--- a/cuegui/cuegui/DarkPalette.py
+++ b/cuegui/cuegui/DarkPalette.py
@@ -35,7 +35,7 @@ def init():
     application and configures the palette and style for the Plastique
     color scheme"""
     QtGui.qApp.setPalette(DarkPalette())
-    if platform.system() == 'Darwin':
+    if platform.system() in ['Darwin', 'Linux']:
         setDarkStyleSheet()
     else:
         QtGui.qApp.setStyle(QtWidgets.QStyleFactory.create(cuegui.Constants.COLOR_THEME))

--- a/cuegui/cuegui/ItemDelegate.py
+++ b/cuegui/cuegui/ItemDelegate.py
@@ -124,9 +124,8 @@ class AbstractDelegate(QtWidgets.QItemDelegate):
 
             # Draw the text
             painter.setPen(QtGui.QColor(index.data(QtCore.Qt.ForegroundRole)))
-            painter.setFont(QtGui.QFont(index.data(QtCore.Qt.FontRole)))
             painter.drawText(option.rect.adjusted(3, -1, -3, 0),
-                             QtCore.Qt.TextAlignmentRole | QtCore.Qt.AlignVCenter,
+                             QtCore.Qt.AlignHCenter | QtCore.Qt.AlignVCenter,
                              str(index.data(QtCore.Qt.DisplayRole)))
         finally:
             painter.restore()


### PR DESCRIPTION
Keep item fonts consistent. Set alignment to center on selection instead of right to make it less jarring.