### PR TITLE
When formatting floats as strings, use root locale

### DIFF
--- a/cuebot/src/main/java/com/imageworks/spcue/LayerStats.java
+++ b/cuebot/src/main/java/com/imageworks/spcue/LayerStats.java
@@ -23,6 +23,7 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Locale;
 
 public class LayerStats {
 
@@ -90,11 +91,12 @@ public class LayerStats {
     }
 
     public String getFormattedHighMemory() {
-        return String.format("%.1fGB", executionSummary.highMemoryKb / 1024.0 / 1024.0);
+        return String.format(Locale.ROOT, "%.1fGB",
+                executionSummary.highMemoryKb / 1024.0 / 1024.0);
     }
 
     public String getFormattedProcHours() {
-        return String.format("%.1f", executionSummary.coreTime / 3600.0);
+        return String.format(Locale.ROOT, "%.1f", executionSummary.coreTime / 3600.0);
     }
 
     public int getFailedFrames() {
@@ -119,7 +121,7 @@ public class LayerStats {
         StringBuilder sb = new StringBuilder(128);
 
         for(ThreadStats t: threadStats) {
-            sb.append(String.format("%.2f", t.getAvgFrameTime() / conversionUnits));
+            sb.append(String.format(Locale.ROOT, "%.2f", t.getAvgFrameTime() / conversionUnits));
             sb.append(",");
         }
         if (sb.length() > 1) {

--- a/cuebot/src/main/java/com/imageworks/spcue/dao/oracle/WhiteboardDaoJdbc.java
+++ b/cuebot/src/main/java/com/imageworks/spcue/dao/oracle/WhiteboardDaoJdbc.java
@@ -24,6 +24,7 @@ import java.sql.SQLException;
 import java.sql.Timestamp;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Locale;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
@@ -1251,7 +1252,8 @@ public class WhiteboardDaoJdbc extends JdbcDaoSupport implements WhiteboardDao {
                         .setUsedMemory(rs.getInt("int_mem_used"));
 
                 if (SqlUtil.getString(rs, "str_host") != null) {
-                    builder.setLastResource(String.format("%s/%2.2f",SqlUtil.getString(rs, "str_host"),
+                    builder.setLastResource(String.format(Locale.ROOT, "%s/%2.2f",
+                            SqlUtil.getString(rs, "str_host"),
                             Convert.coreUnitsToCores(rs.getInt("int_cores"))));
                 }else {
                     builder.setLastResource("");

--- a/cuebot/src/main/java/com/imageworks/spcue/dao/postgres/WhiteboardDaoJdbc.java
+++ b/cuebot/src/main/java/com/imageworks/spcue/dao/postgres/WhiteboardDaoJdbc.java
@@ -1248,7 +1248,7 @@ public class WhiteboardDaoJdbc extends JdbcDaoSupport implements WhiteboardDao {
                             .setUsedMemory(rs.getInt("int_mem_used"));
 
                     if (SqlUtil.getString(rs, "str_host") != null) {
-                        builder.setLastResource(String.format(Locale.ROOT,"%s/%2.2f",
+                        builder.setLastResource(String.format(Locale.ROOT, "%s/%2.2f",
                                 SqlUtil.getString(rs, "str_host"),
                                 Convert.coreUnitsToCores(rs.getInt("int_cores"))));
                     } else {

--- a/cuebot/src/main/java/com/imageworks/spcue/dao/postgres/WhiteboardDaoJdbc.java
+++ b/cuebot/src/main/java/com/imageworks/spcue/dao/postgres/WhiteboardDaoJdbc.java
@@ -24,6 +24,7 @@ import java.sql.SQLException;
 import java.sql.Timestamp;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Locale;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
@@ -1247,7 +1248,8 @@ public class WhiteboardDaoJdbc extends JdbcDaoSupport implements WhiteboardDao {
                             .setUsedMemory(rs.getInt("int_mem_used"));
 
                     if (SqlUtil.getString(rs, "str_host") != null) {
-                        builder.setLastResource(String.format("%s/%2.2f", SqlUtil.getString(rs, "str_host"),
+                        builder.setLastResource(String.format(Locale.ROOT,"%s/%2.2f",
+                                SqlUtil.getString(rs, "str_host"),
                                 Convert.coreUnitsToCores(rs.getInt("int_cores"))));
                     } else {
                         builder.setLastResource("");

--- a/cuebot/src/main/java/com/imageworks/spcue/service/EmailSupport.java
+++ b/cuebot/src/main/java/com/imageworks/spcue/service/EmailSupport.java
@@ -29,6 +29,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Properties;
 
@@ -269,8 +270,10 @@ public class EmailSupport {
             context.put("succeededFrames", String.format("%04d", jts.succeeded));
             context.put("failedFrames",  String.format("%04d", jts.dead + jts.eaten + jts.waiting));
             context.put("checkpointFrames",  String.format("%04d", jts.checkpoint));
-            context.put("maxRSS", String.format("%.1fGB", exj.highMemoryKb / 1024.0 / 1024.0));
-            context.put("coreTime",  String.format("%.1f", exj.coreTime / 3600.0));
+            context.put("maxRSS", String.format(Locale.ROOT, "%.1fGB",
+                    exj.highMemoryKb / 1024.0 / 1024.0));
+            context.put("coreTime",  String.format(Locale.ROOT, "%.1f",
+                    exj.coreTime / 3600.0));
 
             Template t = ve.getTemplate("/conf/webapp/html/email_template.html");
 

--- a/cuebot/src/main/java/com/imageworks/spcue/util/Convert.java
+++ b/cuebot/src/main/java/com/imageworks/spcue/util/Convert.java
@@ -21,6 +21,7 @@ package com.imageworks.spcue.util;
 
 import java.math.BigDecimal;
 import java.util.List;
+import java.util.Locale;
 
 /**
  * Utility class for conversions
@@ -42,7 +43,7 @@ public final class Convert {
 
     public static final float coreUnitsToCores(int coreUnits) {
         if (coreUnits == -1) { return -1f;}
-        return Float.valueOf(String.format("%6.2f",coreUnits / 100.0f));
+        return Float.valueOf(String.format(Locale.ROOT, "%6.2f", coreUnits / 100.0f));
     }
 
     public static final float coreUnitsToWholeCores(int coreUnits) {
@@ -51,7 +52,7 @@ public final class Convert {
     }
 
     private static final List<String> MATCH_BOOL =
-        java.util.Arrays.asList(new String[] { "true","yes","1","on" });
+        java.util.Arrays.asList(new String[] { "true", "yes", "1", "on" });
 
     public static final boolean stringToBool(String value) {
         if (value == null) { return false; }

--- a/cuebot/src/main/java/com/imageworks/spcue/util/CueUtil.java
+++ b/cuebot/src/main/java/com/imageworks/spcue/util/CueUtil.java
@@ -232,11 +232,11 @@ public final class CueUtil {
      * @return String
      */
     public final static String buildFrameName(LayerInterface layer, int num) {
-        return String.format("%04d-%s",num,layer.getName());
+        return String.format("%04d-%s", num, layer.getName());
     }
 
     public final static String buildProcName(String host, int cores) {
-        return String.format(Locale.ROOT, "%s/%4.2f",host, Convert.coreUnitsToCores(cores));
+        return String.format(Locale.ROOT, "%s/%4.2f", host, Convert.coreUnitsToCores(cores));
 
     }
     /**

--- a/cuebot/src/main/java/com/imageworks/spcue/util/CueUtil.java
+++ b/cuebot/src/main/java/com/imageworks/spcue/util/CueUtil.java
@@ -27,6 +27,7 @@ import java.util.Collections;
 import java.util.Date;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Properties;
@@ -235,7 +236,7 @@ public final class CueUtil {
     }
 
     public final static String buildProcName(String host, int cores) {
-        return String.format("%s/%4.2f",host, Convert.coreUnitsToCores(cores));
+        return String.format(Locale.ROOT, "%s/%4.2f",host, Convert.coreUnitsToCores(cores));
 
     }
     /**


### PR DESCRIPTION
Issue #266 
This forces the evaluation of float decimal separators as a `.`