### PR TITLE
Change log level for message when job completes.

### DIFF
--- a/cuegui/cuegui/FrameMonitorTree.py
+++ b/cuegui/cuegui/FrameMonitorTree.py
@@ -423,7 +423,7 @@ class FrameMonitorTree(cuegui.AbstractTreeWidget.AbstractTreeWidget):
         logger.info("_getUpdateChanged")
         if not self.__job or \
            (self.__jobState and self.__jobState == opencue.api.job_pb2.FINISHED):
-            logger.warning("no job or job is finished, bailing")
+            logger.debug("no job or job is finished, bailing")
             return []
         logger.info(" + Nth update = %s" % self.__class__)
         updatedFrames = []


### PR DESCRIPTION
Fixes https://github.com/imageworks/OpenCue/issues/278

This seems to happen on every job completion or close to that, so WARNING is far too high. DEBUG is more appropriate since it indicates normal functioning of the system.