### PR TITLE
Allow more rqconstants to be overwritten by config

### DIFF
--- a/rqd/rqd/rqconstants.py
+++ b/rqd/rqd/rqconstants.py
@@ -167,6 +167,12 @@ try:
             ALLOW_PLAYBLAST = config.getboolean(__section, "PLAYBLAST")
         if config.has_option(__section, "LOAD_MODIFIER"):
             LOAD_MODIFIER = config.getint(__section, "LOAD_MODIFIER")
+        if config.has_option(__section, "RQD_USE_IP_AS_HOSTNAME"):
+            RQD_USE_IP_AS_HOSTNAME = config.getboolean(__section, "RQD_USE_IP_AS_HOSTNAME")
+        if config.has_option(__section, "DEFAULT_FACILITY"):
+            DEFAULT_FACILITY = config.get(__section, "DEFAULT_FACILITY")
+        if config.has_option(__section, "LAUNCH_FRAME_USER_GID"):
+            DEFAULT_FACILITY = config.getint(__section, "LAUNCH_FRAME_USER_GID")
 except Exception, e:
     logging.warning("Failed to read values from config file %s due to %s at %s" % (CONFIG_FILE, e, traceback.extract_tb(sys.exc_info()[2])))
 

--- a/rqd/rqd/rqconstants.py
+++ b/rqd/rqd/rqconstants.py
@@ -172,7 +172,7 @@ try:
         if config.has_option(__section, "DEFAULT_FACILITY"):
             DEFAULT_FACILITY = config.get(__section, "DEFAULT_FACILITY")
         if config.has_option(__section, "LAUNCH_FRAME_USER_GID"):
-            DEFAULT_FACILITY = config.getint(__section, "LAUNCH_FRAME_USER_GID")
+            LAUNCH_FRAME_USER_GID = config.getint(__section, "LAUNCH_FRAME_USER_GID")
 except Exception, e:
     logging.warning("Failed to read values from config file %s due to %s at %s" % (CONFIG_FILE, e, traceback.extract_tb(sys.exc_info()[2])))
 


### PR DESCRIPTION
#271 enchancement.

Allowed...
* RQD_USE_IP_AS_HOSTNAME
* DEFAULT_FACILITY
* LAUNCH_FRAME_USER_GID
...to be overriden in rqd.conf

-C