### PR TITLE
Pycue small bugs

### DIFF
--- a/pycue/opencue/search.py
+++ b/pycue/opencue/search.py
@@ -72,7 +72,7 @@ class BaseSearch(object):
         self.options = options
 
     def search(self):
-        return self.byOptions(self.options)
+        return self.byOptions(**self.options)
 
     @classmethod
     def byOptions(cls, **options):

--- a/pycue/opencue/wrappers/show.py
+++ b/pycue/opencue/wrappers/show.py
@@ -134,7 +134,7 @@ class Show(object):
         @return: response is empty
         """
         response = self.stub.SetDefaultMinCores(show_pb2.ShowSetDefaultMinCoresRequest(
-            show=self.data, max_cores=mincores),
+            show=self.data, min_cores=mincores),
             timeout=Cuebot.Timeout)
         return response
 


### PR DESCRIPTION
Fixing couple small bugs in Pycue.

* `BaseSearch.search` function should expand options when calling `byOptions`.
* Typo fix, `setDefaultMinCores` should set `min_cores`.