### PR TITLE
Allow for override of cuegui.Constants.DEFAULT_INI_PATH

### DIFF
--- a/cuegui/cuegui/Constants.py
+++ b/cuegui/cuegui/Constants.py
@@ -52,7 +52,7 @@ STANDARD_ROW_HEIGHT = 16  # 14
 MEMORY_WARNING_LEVEL = 5242880
 
 RESOURCE_PATH = os.path.dirname(__file__) + "/images"
-DEFAULT_INI_PATH = os.path.dirname(__file__) + "/config"
+DEFAULT_INI_PATH = os.getenv('CUEGUI_DEFAULT_INI_PATH', os.path.dirname(__file__) + '/config')
 
 DEFAULT_PLUGIN_PATHS = [os.path.dirname(__file__) + "/plugins"]
 

--- a/cuegui/cuegui/Main.py
+++ b/cuegui/cuegui/Main.py
@@ -92,9 +92,14 @@ def startup(app_name, app_version, argv):
     cuegui.Style.init()
 
     # If the config file does not exist, copy over the default
+    if os.getenv('CUEGUI_DEFAULT_INI_PATH'):
+        default_ini_path = os.getenv('CUEGUI_DEFAULT_INI_PATH')
+    else:
+        default_ini_path = cuegui.Constants.DEFAULT_INI_PATH
+
     local = settings.fileName()
     if not os.path.exists(local):
-        default = os.path.join(cuegui.Constants.DEFAULT_INI_PATH, "%s.ini" % app_name.lower())
+        default = os.path.join(default_ini_path, "%s.ini" % app_name.lower())
         logger.warning('Not found: %s\nCopying:   %s' % (local, default))
         try:
             os.mkdir(os.path.dirname(local))

--- a/cuegui/cuegui/Main.py
+++ b/cuegui/cuegui/Main.py
@@ -92,14 +92,9 @@ def startup(app_name, app_version, argv):
     cuegui.Style.init()
 
     # If the config file does not exist, copy over the default
-    if os.getenv('CUEGUI_DEFAULT_INI_PATH'):
-        default_ini_path = os.getenv('CUEGUI_DEFAULT_INI_PATH')
-    else:
-        default_ini_path = cuegui.Constants.DEFAULT_INI_PATH
-
     local = settings.fileName()
     if not os.path.exists(local):
-        default = os.path.join(default_ini_path, "%s.ini" % app_name.lower())
+        default = os.path.join(cuegui.Constants.DEFAULT_INI_PATH, "%s.ini" % app_name.lower())
         logger.warning('Not found: %s\nCopying:   %s' % (local, default))
         try:
             os.mkdir(os.path.dirname(local))


### PR DESCRIPTION
#285 enhancement.

Updated Main.py in cuegui to check for CUEGUI_DEFAULT_INI_PATH environment variable before defaulting to Constants.DEFAULT_INI_PATH when creating config.ini for first-time launches of CueGUI.