### PR TITLE
Respect job priorities in the dispatcher

### DIFF
--- a/cuebot/src/main/java/com/imageworks/spcue/DispatchJob.java
+++ b/cuebot/src/main/java/com/imageworks/spcue/DispatchJob.java
@@ -23,6 +23,7 @@ import com.imageworks.spcue.grpc.job.JobState;
 
 public class DispatchJob extends JobEntity implements JobInterface {
     public int maxRetries;
+    public int priority;
     public boolean paused;
     public boolean autoEat;
     public boolean autoBook;

--- a/cuebot/src/main/java/com/imageworks/spcue/DispatchJob.java
+++ b/cuebot/src/main/java/com/imageworks/spcue/DispatchJob.java
@@ -23,7 +23,6 @@ import com.imageworks.spcue.grpc.job.JobState;
 
 public class DispatchJob extends JobEntity implements JobInterface {
     public int maxRetries;
-    public int priority;
     public boolean paused;
     public boolean autoEat;
     public boolean autoBook;

--- a/cuebot/src/main/java/com/imageworks/spcue/dao/DispatcherDao.java
+++ b/cuebot/src/main/java/com/imageworks/spcue/dao/DispatcherDao.java
@@ -25,6 +25,7 @@ import java.util.Set;
 import com.imageworks.spcue.DispatchFrame;
 import com.imageworks.spcue.DispatchHost;
 import com.imageworks.spcue.GroupInterface;
+import com.imageworks.spcue.JobDetail;
 import com.imageworks.spcue.JobInterface;
 import com.imageworks.spcue.LayerInterface;
 import com.imageworks.spcue.ShowInterface;
@@ -112,6 +113,15 @@ public interface DispatcherDao {
      * @return
      */
     boolean findUnderProcedJob(JobInterface excludeJob, VirtualProc proc);
+
+    /**
+     * Returns true if there exists a higher priority job than the base job
+     *
+     * @param baseJob
+     * @param proc
+     * @return boolean
+     */
+    boolean findHigherPriorityJob(JobDetail baseJob, VirtualProc proc);
 
     /**
     * Dispatch the given host to the specified show.  Look for a max of numJobs.

--- a/cuebot/src/main/java/com/imageworks/spcue/dao/DispatcherDao.java
+++ b/cuebot/src/main/java/com/imageworks/spcue/dao/DispatcherDao.java
@@ -121,7 +121,7 @@ public interface DispatcherDao {
      * @param proc
      * @return boolean
      */
-    boolean findHigherPriorityJob(JobDetail baseJob, VirtualProc proc);
+    boolean higherPriorityJobExists(JobDetail baseJob, VirtualProc proc);
 
     /**
     * Dispatch the given host to the specified show.  Look for a max of numJobs.

--- a/cuebot/src/main/java/com/imageworks/spcue/dao/oracle/DispatchQuery.java
+++ b/cuebot/src/main/java/com/imageworks/spcue/dao/oracle/DispatchQuery.java
@@ -145,7 +145,7 @@ public class DispatchQuery {
      * under its minimum and can take the proc.
      *
      * The current job the proc is on is excluded.  This should only be run
-     * if the exluded job is actually over its min proc.
+     * if the excluded job is actually over its min proc.
      *
      * Does not unbook for Utility frames
      *
@@ -220,13 +220,13 @@ public class DispatchQuery {
      * It checks to see if there is another job someplace that is
      * at a higher priority and can take the proc.
      *
-     * The current job the proc is on is excluded.  This should only brun
-     * if the exluded job is actually over its min proc.
+     * The current job the proc is on is excluded.  This should only be run
+     * if the excluded job is actually over its min proc.
      *
      * Does not unbook for Utility frames
      *
      */
-    public static final String FIND_HIGHER_PRIORITY_JOB_BY_FACILITY =
+    public static final String HIGHER_PRIORITY_JOB_BY_FACILITY_EXISTS =
             "SELECT " +
                     "1 " +
                 "FROM " +

--- a/cuebot/src/main/java/com/imageworks/spcue/dao/oracle/DispatchQuery.java
+++ b/cuebot/src/main/java/com/imageworks/spcue/dao/oracle/DispatchQuery.java
@@ -22,15 +22,12 @@ package com.imageworks.spcue.dao.oracle;
 public class DispatchQuery {
 
     public static final String FIND_JOBS_BY_SHOW =
-        "/* FIND_JOBS_BY_SHOW */ SELECT pk_job, float_tier, rank FROM ( " +
+        "/* FIND_JOBS_BY_SHOW */ " +
+        "SELECT pk_job, int_priority, rank FROM ( " +
             "SELECT " +
-                "ROW_NUMBER() OVER (ORDER BY " +
-                    "point.float_tier ASC, " +
-                    "folder_resource.float_tier ASC, " +
-                    "job_resource.float_tier ASC " +
-                    ") AS rank," +
+                "ROW_NUMBER() OVER (ORDER BY job_resource.int_priority DESC) AS rank, " +
                 "job.pk_job, " +
-                "job_resource.float_tier " +
+                "job_resource.int_priority " +
             "FROM " +
                 "job            , " +
                 "job_resource   , " +
@@ -147,7 +144,7 @@ public class DispatchQuery {
      * It checks to see if there is another job someplace that is
      * under its minimum and can take the proc.
      *
-     * The current job the proc is on is excluded.  This should only brun
+     * The current job the proc is on is excluded.  This should only be run
      * if the exluded job is actually over its min proc.
      *
      * Does not unbook for Utility frames
@@ -172,7 +169,7 @@ public class DispatchQuery {
         "AND " +
             "job_resource.float_tier < 1.00 " +
         "AND " +
-            "job_resource.int_cores < job_resource.int_max_cores " +
+            "job_resource.int_cores < job_resource.int_min_cores " +
         "AND " +
             "job.str_state = 'PENDING' " +
         "AND " +
@@ -217,6 +214,78 @@ public class DispatchQuery {
                 "AND " +
                     "CATSEARCH(h.str_tags, l.str_tags, ?) > 0) " +
     "AND ROWNUM < 2 ";
+
+    /**
+     * This query is run before a proc is dispatched to the next frame.
+     * It checks to see if there is another job someplace that is
+     * at a higher priority and can take the proc.
+     *
+     * The current job the proc is on is excluded.  This should only brun
+     * if the exluded job is actually over its min proc.
+     *
+     * Does not unbook for Utility frames
+     *
+     */
+    public static final String FIND_HIGHER_PRIORITY_JOB_BY_FACILITY =
+            "SELECT " +
+                    "1 " +
+                "FROM " +
+                    "job, " +
+                    "job_resource, " +
+                    "folder, " +
+                    "folder_resource " +
+                "WHERE " +
+                    "job.pk_job = job_resource.pk_job " +
+                "AND " +
+                    "job.pk_folder = folder.pk_folder " +
+                "AND " +
+                    "folder.pk_folder = folder_resource.pk_folder " +
+                "AND " +
+                    "(folder_resource.int_max_cores = -1 OR folder_resource.int_cores < folder_resource.int_max_cores) " +
+                "AND " +
+                    "job_resource.int_priority > ?" +
+                "AND " +
+                    "job_resource.int_cores < job_resource.int_max_cores " +
+                "AND " +
+                    "job.str_state = 'PENDING' " +
+                "AND " +
+                    "job.b_paused = 0 " +
+                "AND " +
+                    "job.pk_facility = ? " +
+                "AND " +
+                    "job.str_os = ? " +
+                "AND " +
+                    "job.pk_job IN ( " +
+                        "SELECT /* index (h i_str_host_tag) */ " +
+                            "l.pk_job " +
+                        "FROM " +
+                            "job j, " +
+                            "layer l, " +
+                            "layer_stat lst, " +
+                            "host h " +
+                        "WHERE " +
+                            "j.pk_job = l.pk_job " +
+                        "AND " +
+                            "j.str_state = 'PENDING' " +
+                        "AND " +
+                            "j.b_paused = 0 " +
+                        "AND " +
+                            "j.pk_facility = ? " +
+                        "AND " +
+                            "j.str_os = ? " +
+                        "AND " +
+                            "(CASE WHEN lst.int_waiting_count > 0 THEN lst.pk_layer ELSE NULL END) = l.pk_layer " +
+                        "AND " +
+                            "(CASE WHEN lst.int_waiting_count > 0 THEN 1 ELSE NULL END) = 1 " +
+                        "AND " +
+                            "l.int_cores_min <= ? " +
+                        "AND " +
+                            "l.int_mem_min <= ? " +
+                        "AND " +
+                            "l.int_gpu_min = ? " +
+                        "AND " +
+                            "CATSEARCH(h.str_tags, l.str_tags, ?) > 0) " +
+                "AND ROWNUM < 2 ";
 
     /**
      * Finds the next frame in a job for a proc.

--- a/cuebot/src/main/java/com/imageworks/spcue/dao/oracle/DispatcherDaoJdbc.java
+++ b/cuebot/src/main/java/com/imageworks/spcue/dao/oracle/DispatcherDaoJdbc.java
@@ -36,6 +36,7 @@ import com.imageworks.spcue.AllocationInterface;
 import com.imageworks.spcue.DispatchFrame;
 import com.imageworks.spcue.DispatchHost;
 import com.imageworks.spcue.GroupInterface;
+import com.imageworks.spcue.JobDetail;
 import com.imageworks.spcue.JobInterface;
 import com.imageworks.spcue.LayerInterface;
 import com.imageworks.spcue.ShowInterface;
@@ -57,7 +58,9 @@ import static com.imageworks.spcue.dao.oracle.DispatchQuery.FIND_LOCAL_DISPATCH_
 import static com.imageworks.spcue.dao.oracle.DispatchQuery.FIND_LOCAL_DISPATCH_FRAME_BY_LAYER_AND_HOST;
 import static com.imageworks.spcue.dao.oracle.DispatchQuery.FIND_LOCAL_DISPATCH_FRAME_BY_LAYER_AND_PROC;
 import static com.imageworks.spcue.dao.oracle.DispatchQuery.FIND_SHOWS;
+import static com.imageworks.spcue.dao.oracle.DispatchQuery.FIND_HIGHER_PRIORITY_JOB_BY_FACILITY;
 import static com.imageworks.spcue.dao.oracle.DispatchQuery.FIND_UNDER_PROCED_JOB_BY_FACILITY;
+
 
 /**
  * Dispatcher DAO
@@ -351,6 +354,24 @@ public class DispatcherDaoJdbc extends JdbcDaoSupport implements DispatcherDao {
          finally {
              logger.trace("findUnderProcedJob(Job excludeJob, VirtualProc proc) " + CueUtil.duration(start));
          }
+    }
+
+    @Override
+    public boolean findHigherPriorityJob(JobDetail baseJob, VirtualProc proc) {
+        long start = System.currentTimeMillis();
+        try {
+            return getJdbcTemplate().queryForObject(
+                    FIND_HIGHER_PRIORITY_JOB_BY_FACILITY,
+                    Integer.class, baseJob.priority, proc.getFacilityId(),
+                    proc.os, proc.getFacilityId(), proc.os,
+                    proc.coresReserved, proc.memoryReserved, proc.gpuReserved,
+                    hostString(proc.hostName)) > 0;
+        } catch (org.springframework.dao.EmptyResultDataAccessException e) {
+            return false;
+        }
+        finally {
+            logger.trace("findHigherPriorityJob(JobDetail baseJob, VirtualProc proc) " + CueUtil.duration(start));
+        }
     }
 
     @Override

--- a/cuebot/src/main/java/com/imageworks/spcue/dao/oracle/DispatcherDaoJdbc.java
+++ b/cuebot/src/main/java/com/imageworks/spcue/dao/oracle/DispatcherDaoJdbc.java
@@ -58,8 +58,9 @@ import static com.imageworks.spcue.dao.oracle.DispatchQuery.FIND_LOCAL_DISPATCH_
 import static com.imageworks.spcue.dao.oracle.DispatchQuery.FIND_LOCAL_DISPATCH_FRAME_BY_LAYER_AND_HOST;
 import static com.imageworks.spcue.dao.oracle.DispatchQuery.FIND_LOCAL_DISPATCH_FRAME_BY_LAYER_AND_PROC;
 import static com.imageworks.spcue.dao.oracle.DispatchQuery.FIND_SHOWS;
-import static com.imageworks.spcue.dao.oracle.DispatchQuery.FIND_HIGHER_PRIORITY_JOB_BY_FACILITY;
 import static com.imageworks.spcue.dao.oracle.DispatchQuery.FIND_UNDER_PROCED_JOB_BY_FACILITY;
+import static com.imageworks.spcue.dao.oracle.DispatchQuery.HIGHER_PRIORITY_JOB_BY_FACILITY_EXISTS;
+
 
 
 /**
@@ -357,20 +358,20 @@ public class DispatcherDaoJdbc extends JdbcDaoSupport implements DispatcherDao {
     }
 
     @Override
-    public boolean findHigherPriorityJob(JobDetail baseJob, VirtualProc proc) {
+    public boolean higherPriorityJobExists(JobDetail baseJob, VirtualProc proc) {
         long start = System.currentTimeMillis();
         try {
             return getJdbcTemplate().queryForObject(
-                    FIND_HIGHER_PRIORITY_JOB_BY_FACILITY,
-                    Integer.class, baseJob.priority, proc.getFacilityId(),
+                    HIGHER_PRIORITY_JOB_BY_FACILITY_EXISTS,
+                    Boolean.class, baseJob.priority, proc.getFacilityId(),
                     proc.os, proc.getFacilityId(), proc.os,
                     proc.coresReserved, proc.memoryReserved, proc.gpuReserved,
-                    hostString(proc.hostName)) > 0;
+                    hostString(proc.hostName));
         } catch (org.springframework.dao.EmptyResultDataAccessException e) {
             return false;
         }
         finally {
-            logger.trace("findHigherPriorityJob(JobDetail baseJob, VirtualProc proc) " + CueUtil.duration(start));
+            logger.trace("higherPriorityJobExists(JobDetail baseJob, VirtualProc proc) " + CueUtil.duration(start));
         }
     }
 

--- a/cuebot/src/main/java/com/imageworks/spcue/dao/postgres/DispatchQuery.java
+++ b/cuebot/src/main/java/com/imageworks/spcue/dao/postgres/DispatchQuery.java
@@ -150,7 +150,7 @@ public class DispatchQuery {
      * under its minimum and can take the proc.
      *
      * The current job the proc is on is excluded.  This should only be run
-     * if the exluded job is actually over its min proc.
+     * if the excluded job is actually over its min proc.
      *
      * Does not unbook for Utility frames
      *
@@ -228,13 +228,13 @@ public class DispatchQuery {
      * It checks to see if there is another job someplace that is
      * at a higher priority and can take the proc.
      *
-     * The current job the proc is on is excluded.  This should only run
-     * if the exluded job is actually over its min proc.
+     * The current job the proc is on is excluded.  This should only be run
+     * if the excluded job is actually over its min proc.
      *
      * Does not unbook for Utility frames
      *
      */
-    public static final String FIND_HIGHER_PRIORITY_JOB_BY_FACILITY =
+    public static final String HIGHER_PRIORITY_JOB_BY_FACILITY_EXISTS =
             "SELECT " +
                 "1 " +
             "FROM " +

--- a/cuebot/src/main/java/com/imageworks/spcue/dao/postgres/DispatchQuery.java
+++ b/cuebot/src/main/java/com/imageworks/spcue/dao/postgres/DispatchQuery.java
@@ -22,15 +22,12 @@ package com.imageworks.spcue.dao.postgres;
 public class DispatchQuery {
 
     public static final String FIND_JOBS_BY_SHOW =
-        "/* FIND_JOBS_BY_SHOW */ SELECT pk_job, float_tier, rank FROM ( " +
+        "/* FIND_JOBS_BY_SHOW */ " +
+        "SELECT pk_job, int_priority, rank FROM ( " +
             "SELECT " +
-                "ROW_NUMBER() OVER (ORDER BY " +
-                    "point.float_tier ASC, " +
-                    "folder_resource.float_tier ASC, " +
-                    "job_resource.float_tier ASC " +
-                    ") AS rank, " +
+                "ROW_NUMBER() OVER (ORDER BY job_resource.int_priority DESC) AS rank, " +
                 "job.pk_job, " +
-                "job_resource.float_tier " +
+                "job_resource.int_priority " +
             "FROM " +
                 "job            , " +
                 "job_resource   , " +
@@ -152,7 +149,7 @@ public class DispatchQuery {
      * It checks to see if there is another job someplace that is
      * under its minimum and can take the proc.
      *
-     * The current job the proc is on is excluded.  This should only brun
+     * The current job the proc is on is excluded.  This should only be run
      * if the exluded job is actually over its min proc.
      *
      * Does not unbook for Utility frames
@@ -177,7 +174,7 @@ public class DispatchQuery {
         "AND " +
             "job_resource.float_tier < 1.00 " +
         "AND " +
-            "job_resource.int_cores < job_resource.int_max_cores " +
+            "job_resource.int_cores < job_resource.int_min_cores " +
         "AND " +
             "job.str_state = 'PENDING' " +
         "AND " +
@@ -225,6 +222,81 @@ public class DispatchQuery {
                     "h.str_name = ? " +
             ") " +
         "LIMIT 1";
+
+    /**
+     * This query is run before a proc is dispatched to the next frame.
+     * It checks to see if there is another job someplace that is
+     * at a higher priority and can take the proc.
+     *
+     * The current job the proc is on is excluded.  This should only run
+     * if the exluded job is actually over its min proc.
+     *
+     * Does not unbook for Utility frames
+     *
+     */
+    public static final String FIND_HIGHER_PRIORITY_JOB_BY_FACILITY =
+            "SELECT " +
+                "1 " +
+            "FROM " +
+                "job, " +
+                "job_resource, " +
+                "folder, " +
+                "folder_resource " +
+            "WHERE " +
+                "job.pk_job = job_resource.pk_job " +
+            "AND " +
+                "job.pk_folder = folder.pk_folder " +
+            "AND " +
+                "folder.pk_folder = folder_resource.pk_folder " +
+            "AND " +
+                "(folder_resource.int_max_cores = -1 OR folder_resource.int_cores < folder_resource.int_max_cores) " +
+            "AND " +
+                "job_resource.int_priority > ?" +
+            "AND " +
+                "job_resource.int_cores < job_resource.int_max_cores " +
+            "AND " +
+                "job.str_state = 'PENDING' " +
+            "AND " +
+                "job.b_paused = false " +
+            "AND " +
+                "job.pk_facility = ? " +
+            "AND " +
+                "job.str_os = ? " +
+            "AND " +
+                "job.pk_job IN ( " +
+                    "SELECT /* index (h i_str_host_tag) */ " +
+                        "l.pk_job " +
+                    "FROM " +
+                        "job j, " +
+                        "layer l, " +
+                        "layer_stat lst, " +
+                        "host h " +
+                    "WHERE " +
+                        "j.pk_job = l.pk_job " +
+                    "AND " +
+                        "j.str_state = 'PENDING' " +
+                    "AND " +
+                        "j.b_paused = false " +
+                    "AND " +
+                        "j.pk_facility = ? " +
+                    "AND " +
+                        "j.str_os = ? " +
+                    "AND " +
+                        "(CASE WHEN lst.int_waiting_count > 0 THEN lst.pk_layer ELSE NULL END) = l.pk_layer " +
+                    "AND " +
+                        "(CASE WHEN lst.int_waiting_count > 0 THEN 1 ELSE NULL END) = 1 " +
+                    "AND " +
+                        "l.int_cores_min <= ? " +
+                    "AND " +
+                        "l.int_mem_min <= ? " +
+                    "AND " +
+                        "l.int_gpu_min = ? " +
+                    "AND " +
+                        "h.str_tags ~* ('(?x)' || l.str_tags) " +
+                    "AND " +
+                        "h.str_name = ? " +
+                ") " +
+            "LIMIT 1";
 
     /**
      * Finds the next frame in a job for a proc.

--- a/cuebot/src/main/java/com/imageworks/spcue/dao/postgres/DispatcherDaoJdbc.java
+++ b/cuebot/src/main/java/com/imageworks/spcue/dao/postgres/DispatcherDaoJdbc.java
@@ -35,6 +35,7 @@ import com.imageworks.spcue.AllocationInterface;
 import com.imageworks.spcue.DispatchFrame;
 import com.imageworks.spcue.DispatchHost;
 import com.imageworks.spcue.GroupInterface;
+import com.imageworks.spcue.JobDetail;
 import com.imageworks.spcue.JobInterface;
 import com.imageworks.spcue.LayerInterface;
 import com.imageworks.spcue.ShowInterface;
@@ -56,6 +57,7 @@ import static com.imageworks.spcue.dao.postgres.DispatchQuery.FIND_LOCAL_DISPATC
 import static com.imageworks.spcue.dao.postgres.DispatchQuery.FIND_LOCAL_DISPATCH_FRAME_BY_LAYER_AND_HOST;
 import static com.imageworks.spcue.dao.postgres.DispatchQuery.FIND_LOCAL_DISPATCH_FRAME_BY_LAYER_AND_PROC;
 import static com.imageworks.spcue.dao.postgres.DispatchQuery.FIND_SHOWS;
+import static com.imageworks.spcue.dao.postgres.DispatchQuery.FIND_HIGHER_PRIORITY_JOB_BY_FACILITY;
 import static com.imageworks.spcue.dao.postgres.DispatchQuery.FIND_UNDER_PROCED_JOB_BY_FACILITY;
 
 
@@ -351,6 +353,24 @@ public class DispatcherDaoJdbc extends JdbcDaoSupport implements DispatcherDao {
          finally {
              logger.trace("findUnderProcedJob(Job excludeJob, VirtualProc proc) " + CueUtil.duration(start));
          }
+    }
+
+    @Override
+    public boolean findHigherPriorityJob(JobDetail baseJob, VirtualProc proc) {
+        long start = System.currentTimeMillis();
+        try {
+            return getJdbcTemplate().queryForObject(
+                    FIND_HIGHER_PRIORITY_JOB_BY_FACILITY,
+                    Integer.class, baseJob.priority, proc.getFacilityId(),
+                    proc.os, proc.getFacilityId(), proc.os,
+                    proc.coresReserved, proc.memoryReserved, proc.gpuReserved,
+                    proc.hostName) > 0;
+        } catch (org.springframework.dao.EmptyResultDataAccessException e) {
+            return false;
+        }
+        finally {
+            logger.trace("findHigherPriorityJob(JobDetail baseJob, VirtualProc proc) " + CueUtil.duration(start));
+        }
     }
 
     @Override

--- a/cuebot/src/main/java/com/imageworks/spcue/dao/postgres/DispatcherDaoJdbc.java
+++ b/cuebot/src/main/java/com/imageworks/spcue/dao/postgres/DispatcherDaoJdbc.java
@@ -57,8 +57,8 @@ import static com.imageworks.spcue.dao.postgres.DispatchQuery.FIND_LOCAL_DISPATC
 import static com.imageworks.spcue.dao.postgres.DispatchQuery.FIND_LOCAL_DISPATCH_FRAME_BY_LAYER_AND_HOST;
 import static com.imageworks.spcue.dao.postgres.DispatchQuery.FIND_LOCAL_DISPATCH_FRAME_BY_LAYER_AND_PROC;
 import static com.imageworks.spcue.dao.postgres.DispatchQuery.FIND_SHOWS;
-import static com.imageworks.spcue.dao.postgres.DispatchQuery.FIND_HIGHER_PRIORITY_JOB_BY_FACILITY;
 import static com.imageworks.spcue.dao.postgres.DispatchQuery.FIND_UNDER_PROCED_JOB_BY_FACILITY;
+import static com.imageworks.spcue.dao.postgres.DispatchQuery.HIGHER_PRIORITY_JOB_BY_FACILITY_EXISTS;
 
 
 /**
@@ -356,20 +356,20 @@ public class DispatcherDaoJdbc extends JdbcDaoSupport implements DispatcherDao {
     }
 
     @Override
-    public boolean findHigherPriorityJob(JobDetail baseJob, VirtualProc proc) {
+    public boolean higherPriorityJobExists(JobDetail baseJob, VirtualProc proc) {
         long start = System.currentTimeMillis();
         try {
             return getJdbcTemplate().queryForObject(
-                    FIND_HIGHER_PRIORITY_JOB_BY_FACILITY,
-                    Integer.class, baseJob.priority, proc.getFacilityId(),
+                    HIGHER_PRIORITY_JOB_BY_FACILITY_EXISTS,
+                    Boolean.class, baseJob.priority, proc.getFacilityId(),
                     proc.os, proc.getFacilityId(), proc.os,
                     proc.coresReserved, proc.memoryReserved, proc.gpuReserved,
-                    proc.hostName) > 0;
+                    proc.hostName);
         } catch (org.springframework.dao.EmptyResultDataAccessException e) {
             return false;
         }
         finally {
-            logger.trace("findHigherPriorityJob(JobDetail baseJob, VirtualProc proc) " + CueUtil.duration(start));
+            logger.trace("higherPriorityJobExists(JobDetail baseJob, VirtualProc proc) " + CueUtil.duration(start));
         }
     }
 

--- a/cuebot/src/main/java/com/imageworks/spcue/dispatcher/DispatchSupport.java
+++ b/cuebot/src/main/java/com/imageworks/spcue/dispatcher/DispatchSupport.java
@@ -30,6 +30,7 @@ import com.imageworks.spcue.FacilityInterface;
 import com.imageworks.spcue.FrameInterface;
 import com.imageworks.spcue.GroupInterface;
 import com.imageworks.spcue.HostInterface;
+import com.imageworks.spcue.JobDetail;
 import com.imageworks.spcue.JobInterface;
 import com.imageworks.spcue.LayerInterface;
 import com.imageworks.spcue.ProcInterface;
@@ -255,6 +256,15 @@ public interface DispatchSupport {
      * @return
      */
     boolean findUnderProcedJob(JobInterface excludeJob, VirtualProc proc);
+
+    /**
+     * Return true if there are higher priority jobs to run.
+     *
+     * @param baseJob
+     * @param proc
+     * @return boolean
+     */
+    boolean findHigherPriorityJob(JobDetail baseJob, VirtualProc proc);
 
     /**
      * Run the frame on the specified proc.

--- a/cuebot/src/main/java/com/imageworks/spcue/dispatcher/DispatchSupport.java
+++ b/cuebot/src/main/java/com/imageworks/spcue/dispatcher/DispatchSupport.java
@@ -264,7 +264,7 @@ public interface DispatchSupport {
      * @param proc
      * @return boolean
      */
-    boolean findHigherPriorityJob(JobDetail baseJob, VirtualProc proc);
+    boolean higherPriorityJobExists(JobDetail baseJob, VirtualProc proc);
 
     /**
      * Run the frame on the specified proc.

--- a/cuebot/src/main/java/com/imageworks/spcue/dispatcher/DispatchSupportService.java
+++ b/cuebot/src/main/java/com/imageworks/spcue/dispatcher/DispatchSupportService.java
@@ -142,8 +142,8 @@ public class DispatchSupportService implements DispatchSupport {
     }
 
     @Transactional(readOnly = true)
-    public boolean findHigherPriorityJob(JobDetail baseJob, VirtualProc proc) {
-        return dispatcherDao.findHigherPriorityJob(baseJob, proc);
+    public boolean higherPriorityJobExists(JobDetail baseJob, VirtualProc proc) {
+        return dispatcherDao.higherPriorityJobExists(baseJob, proc);
     }
 
     @Transactional(readOnly = true)

--- a/cuebot/src/main/java/com/imageworks/spcue/dispatcher/DispatchSupportService.java
+++ b/cuebot/src/main/java/com/imageworks/spcue/dispatcher/DispatchSupportService.java
@@ -35,6 +35,7 @@ import com.imageworks.spcue.FacilityInterface;
 import com.imageworks.spcue.FrameInterface;
 import com.imageworks.spcue.GroupInterface;
 import com.imageworks.spcue.HostInterface;
+import com.imageworks.spcue.JobDetail;
 import com.imageworks.spcue.JobInterface;
 import com.imageworks.spcue.LayerInterface;
 import com.imageworks.spcue.ProcInterface;
@@ -138,6 +139,11 @@ public class DispatchSupportService implements DispatchSupport {
     @Transactional(readOnly = true)
     public boolean findUnderProcedJob(JobInterface excludeJob, VirtualProc proc) {
         return dispatcherDao.findUnderProcedJob(excludeJob, proc);
+    }
+
+    @Transactional(readOnly = true)
+    public boolean findHigherPriorityJob(JobDetail baseJob, VirtualProc proc) {
+        return dispatcherDao.findHigherPriorityJob(baseJob, proc);
     }
 
     @Transactional(readOnly = true)

--- a/cuebot/src/main/java/com/imageworks/spcue/dispatcher/Dispatcher.java
+++ b/cuebot/src/main/java/com/imageworks/spcue/dispatcher/Dispatcher.java
@@ -123,7 +123,8 @@ public interface Dispatcher {
     public static final int ORPHANED_SECONDS = 300;
 
     // The chance a frame will unbook itself to run a higher priority frame.
-    public static final int UNBOOK_FREQUENCY = 50;
+    // 0 will never unbook, > 100 will always unbook.
+    public static final int UNBOOK_FREQUENCY = 101;
 
     // The default operating system assigned to host that don't report one.
     public static final String OS_DEFAULT = "rhel40";

--- a/cuebot/src/main/java/com/imageworks/spcue/dispatcher/FrameCompleteHandler.java
+++ b/cuebot/src/main/java/com/imageworks/spcue/dispatcher/FrameCompleteHandler.java
@@ -29,6 +29,7 @@ import org.springframework.dao.EmptyResultDataAccessException;
 import com.imageworks.spcue.DispatchFrame;
 import com.imageworks.spcue.DispatchHost;
 import com.imageworks.spcue.DispatchJob;
+import com.imageworks.spcue.JobDetail;
 import com.imageworks.spcue.LayerInterface;
 import com.imageworks.spcue.Source;
 import com.imageworks.spcue.VirtualProc;
@@ -395,12 +396,24 @@ public class FrameCompleteHandler {
                     && randomNumber.nextInt(100) <= Dispatcher.UNBOOK_FREQUENCY
                     && System.currentTimeMillis() > lastUnbook.get()) {
 
+                // First make sure all jobs have their min cores
+                // Then check for higher priority jobs
+                // If not, rebook this job
                 if (job.autoUnbook && proc.coresReserved >= 100) {
                     if (jobManager.isOverMinCores(job)) {
                         try {
 
                             boolean unbook =
                                     dispatchSupport.findUnderProcedJob(job, proc);
+
+                            if (!unbook) {
+                                JobDetail jobDetail = jobManager.getJobDetail(job.id);
+                                logger.warn("CHECKING Priority...");
+                                logger.warn(jobDetail.priority);
+                                unbook = dispatchSupport.findHigherPriorityJob(jobDetail, proc);
+                                logger.warn("UNBOOK VALUE...");
+                                logger.warn(unbook);
+                            }
 
                             if (unbook) {
 
@@ -449,6 +462,7 @@ public class FrameCompleteHandler {
                     }
                 }
 
+                // Book the next frame of this job on the same proc
                 if (proc.isLocalDispatch) {
                     dispatchQueue.execute(new DispatchNextFrame(job, proc,
                             localDispatcher));

--- a/cuebot/src/main/java/com/imageworks/spcue/dispatcher/FrameCompleteHandler.java
+++ b/cuebot/src/main/java/com/imageworks/spcue/dispatcher/FrameCompleteHandler.java
@@ -408,11 +408,7 @@ public class FrameCompleteHandler {
 
                             if (!unbook) {
                                 JobDetail jobDetail = jobManager.getJobDetail(job.id);
-                                logger.warn("CHECKING Priority...");
-                                logger.warn(jobDetail.priority);
-                                unbook = dispatchSupport.findHigherPriorityJob(jobDetail, proc);
-                                logger.warn("UNBOOK VALUE...");
-                                logger.warn(unbook);
+                                unbook = dispatchSupport.higherPriorityJobExists(jobDetail, proc);
                             }
 
                             if (unbook) {

--- a/cuebot/src/main/java/com/imageworks/spcue/dispatcher/HostReportHandler.java
+++ b/cuebot/src/main/java/com/imageworks/spcue/dispatcher/HostReportHandler.java
@@ -253,7 +253,7 @@ public class HostReportHandler {
             }
 
             /*
-             * If a message was set, the hot is not bookable.  Log
+             * If a message was set, the host is not bookable.  Log
              * the message and move on.
              */
             if (msg != null) {

--- a/cuebot/src/test/java/com/imageworks/spcue/test/dao/oracle/DispatcherDaoTests.java
+++ b/cuebot/src/test/java/com/imageworks/spcue/test/dao/oracle/DispatcherDaoTests.java
@@ -417,7 +417,7 @@ public class DispatcherDaoTests extends AbstractTransactionalJUnit4SpringContext
     @Test
     @Transactional
     @Rollback(true)
-    public void testfindHigherPriorityJob() {
+    public void testHigherPriorityJobExists() {
         DispatchHost host = getHost();
         JobDetail job1 = getJob1();
         JobDetail job2 = getJob2();
@@ -444,7 +444,7 @@ public class DispatcherDaoTests extends AbstractTransactionalJUnit4SpringContext
         proc.coresReserved = 100;
         dispatcher.dispatch(frame, proc);
 
-        boolean higher = dispatcherDao.findHigherPriorityJob(job1, proc);
+        boolean higher = dispatcherDao.higherPriorityJobExists(job1, proc);
         assertTrue(higher);
     }
 }

--- a/cuebot/src/test/java/com/imageworks/spcue/test/dao/oracle/DispatcherDaoTests.java
+++ b/cuebot/src/test/java/com/imageworks/spcue/test/dao/oracle/DispatcherDaoTests.java
@@ -398,13 +398,13 @@ public class DispatcherDaoTests extends AbstractTransactionalJUnit4SpringContext
 
         assertEquals(JobState.PENDING.toString(),
                 jdbcTemplate.queryForObject(
-                "SELECT str_state FROM job WHERE pk_job=?",
-                String.class, job1.id));
+                        "SELECT str_state FROM job WHERE pk_job=?",
+                        String.class, job1.id));
 
         assertEquals(JobState.PENDING.toString(),
                 jdbcTemplate.queryForObject(
-                "SELECT str_state FROM job WHERE pk_job=?",
-                String.class, job2.id));
+                        "SELECT str_state FROM job WHERE pk_job=?",
+                        String.class, job2.id));
 
         VirtualProc proc = VirtualProc.build(host, frame);
         proc.coresReserved = 100;
@@ -412,5 +412,39 @@ public class DispatcherDaoTests extends AbstractTransactionalJUnit4SpringContext
 
         boolean under = dispatcherDao.findUnderProcedJob(job1, proc);
         assertTrue(under);
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testfindHigherPriorityJob() {
+        DispatchHost host = getHost();
+        JobDetail job1 = getJob1();
+        JobDetail job2 = getJob2();
+
+        jobDao.updateMinCores(job1, 0);
+        jobDao.updateMinCores(job2, 0);
+        jobDao.updatePriority(job1, 100);
+        jobDao.updatePriority(job2, 200);
+
+        DispatchFrame frame = dispatcherDao.findNextDispatchFrame(job1, host);
+        assertNotNull(frame);
+
+        assertEquals(JobState.PENDING.toString(),
+                jdbcTemplate.queryForObject(
+                        "SELECT str_state FROM job WHERE pk_job=?",
+                        String.class, job1.id));
+
+        assertEquals(JobState.PENDING.toString(),
+                jdbcTemplate.queryForObject(
+                        "SELECT str_state FROM job WHERE pk_job=?",
+                        String.class, job2.id));
+
+        VirtualProc proc = VirtualProc.build(host, frame);
+        proc.coresReserved = 100;
+        dispatcher.dispatch(frame, proc);
+
+        boolean higher = dispatcherDao.findHigherPriorityJob(job1, proc);
+        assertTrue(higher);
     }
 }

--- a/cuebot/src/test/java/com/imageworks/spcue/test/dao/oracle/DispatcherDaoTests.java
+++ b/cuebot/src/test/java/com/imageworks/spcue/test/dao/oracle/DispatcherDaoTests.java
@@ -64,6 +64,7 @@ import com.imageworks.spcue.test.AssumingOracleEngine;
 import com.imageworks.spcue.util.CueUtil;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
@@ -417,10 +418,12 @@ public class DispatcherDaoTests extends AbstractTransactionalJUnit4SpringContext
     @Test
     @Transactional
     @Rollback(true)
-    public void testHigherPriorityJobExists() {
+    public void testHigherPriorityJobExistsTrue() {
         DispatchHost host = getHost();
         JobDetail job1 = getJob1();
         JobDetail job2 = getJob2();
+        job1.priority = 100;
+        job2.priority = 200;
 
         jobDao.updateMinCores(job1, 0);
         jobDao.updateMinCores(job2, 0);
@@ -444,7 +447,78 @@ public class DispatcherDaoTests extends AbstractTransactionalJUnit4SpringContext
         proc.coresReserved = 100;
         dispatcher.dispatch(frame, proc);
 
-        boolean higher = dispatcherDao.higherPriorityJobExists(job1, proc);
-        assertTrue(higher);
+        boolean isHigher = dispatcherDao.higherPriorityJobExists(job1, proc);
+        assertTrue(isHigher);
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testHigherPriorityJobExistsFalse() {
+        DispatchHost host = getHost();
+        JobDetail job1 = getJob1();
+        JobDetail job2 = getJob2();
+        job1.priority = 20000;
+        job2.priority = 100;
+
+        jobDao.updateMinCores(job1, 0);
+        jobDao.updateMinCores(job2, 0);
+        jobDao.updatePriority(job1, 20000);
+        jobDao.updatePriority(job2, 100);
+
+        DispatchFrame frame = dispatcherDao.findNextDispatchFrame(job1, host);
+        assertNotNull(frame);
+
+        assertEquals(JobState.PENDING.toString(),
+                jdbcTemplate.queryForObject(
+                        "SELECT str_state FROM job WHERE pk_job=?",
+                        String.class, job1.id));
+
+        assertEquals(JobState.PENDING.toString(),
+                jdbcTemplate.queryForObject(
+                        "SELECT str_state FROM job WHERE pk_job=?",
+                        String.class, job2.id));
+
+        VirtualProc proc = VirtualProc.build(host, frame);
+        proc.coresReserved = 100;
+        dispatcher.dispatch(frame, proc);
+
+        boolean isHigher = dispatcherDao.higherPriorityJobExists(job1, proc);
+        assertFalse(isHigher);
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testHigherPriorityJobExistsMaxProcBound() {
+        DispatchHost host = getHost();
+        JobDetail job1 = getJob1();
+        JobDetail job2 = getJob2();
+        job1.priority = 100;
+        job2.priority = 200;
+
+        jobDao.updateMaxCores(job2, 0);
+        jobDao.updatePriority(job1, 100);
+        jobDao.updatePriority(job2, 200);
+
+        DispatchFrame frame = dispatcherDao.findNextDispatchFrame(job1, host);
+        assertNotNull(frame);
+
+        assertEquals(JobState.PENDING.toString(),
+                jdbcTemplate.queryForObject(
+                        "SELECT str_state FROM job WHERE pk_job=?",
+                        String.class, job1.id));
+
+        assertEquals(JobState.PENDING.toString(),
+                jdbcTemplate.queryForObject(
+                        "SELECT str_state FROM job WHERE pk_job=?",
+                        String.class, job2.id));
+
+        VirtualProc proc = VirtualProc.build(host, frame);
+        proc.coresReserved = 100;
+        dispatcher.dispatch(frame, proc);
+
+        boolean isHigher = dispatcherDao.higherPriorityJobExists(job1, proc);
+        assertFalse(isHigher);
     }
 }

--- a/cuebot/src/test/java/com/imageworks/spcue/test/dao/postgres/DispatcherDaoTests.java
+++ b/cuebot/src/test/java/com/imageworks/spcue/test/dao/postgres/DispatcherDaoTests.java
@@ -417,7 +417,7 @@ public class DispatcherDaoTests extends AbstractTransactionalJUnit4SpringContext
     @Test
     @Transactional
     @Rollback(true)
-    public void testfindHigherPriorityJob() {
+    public void testHigherPriorityJobExists() {
         DispatchHost host = getHost();
         JobDetail job1 = getJob1();
         JobDetail job2 = getJob2();
@@ -444,7 +444,7 @@ public class DispatcherDaoTests extends AbstractTransactionalJUnit4SpringContext
         proc.coresReserved = 100;
         dispatcher.dispatch(frame, proc);
 
-        boolean higher = dispatcherDao.findHigherPriorityJob(job1, proc);
+        boolean higher = dispatcherDao.higherPriorityJobExists(job1, proc);
         assertTrue(higher);
     }
 }

--- a/cuebot/src/test/java/com/imageworks/spcue/test/dao/postgres/DispatcherDaoTests.java
+++ b/cuebot/src/test/java/com/imageworks/spcue/test/dao/postgres/DispatcherDaoTests.java
@@ -64,6 +64,7 @@ import com.imageworks.spcue.test.AssumingPostgresEngine;
 import com.imageworks.spcue.util.CueUtil;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
@@ -417,10 +418,12 @@ public class DispatcherDaoTests extends AbstractTransactionalJUnit4SpringContext
     @Test
     @Transactional
     @Rollback(true)
-    public void testHigherPriorityJobExists() {
+    public void testHigherPriorityJobExistsTrue() {
         DispatchHost host = getHost();
         JobDetail job1 = getJob1();
         JobDetail job2 = getJob2();
+        job1.priority = 100;
+        job2.priority = 200;
 
         jobDao.updateMinCores(job1, 0);
         jobDao.updateMinCores(job2, 0);
@@ -444,9 +447,76 @@ public class DispatcherDaoTests extends AbstractTransactionalJUnit4SpringContext
         proc.coresReserved = 100;
         dispatcher.dispatch(frame, proc);
 
-        boolean higher = dispatcherDao.higherPriorityJobExists(job1, proc);
-        assertTrue(higher);
+        boolean isHigher = dispatcherDao.higherPriorityJobExists(job1, proc);
+        assertTrue(isHigher);
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testHigherPriorityJobExistsFalse() {
+        DispatchHost host = getHost();
+        JobDetail job1 = getJob1();
+        JobDetail job2 = getJob2();
+        job1.priority = 20000;
+        job2.priority = 100;
+
+        jobDao.updatePriority(job1, 20000);
+        jobDao.updatePriority(job2, 100);
+
+        DispatchFrame frame = dispatcherDao.findNextDispatchFrame(job1, host);
+        assertNotNull(frame);
+
+        assertEquals(JobState.PENDING.toString(),
+                jdbcTemplate.queryForObject(
+                        "SELECT str_state FROM job WHERE pk_job=?",
+                        String.class, job1.id));
+
+        assertEquals(JobState.PENDING.toString(),
+                jdbcTemplate.queryForObject(
+                        "SELECT str_state FROM job WHERE pk_job=?",
+                        String.class, job2.id));
+
+        VirtualProc proc = VirtualProc.build(host, frame);
+        proc.coresReserved = 100;
+        dispatcher.dispatch(frame, proc);
+
+        boolean isHigher = dispatcherDao.higherPriorityJobExists(job1, proc);
+        assertFalse(isHigher);
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testHigherPriorityJobExistsMaxProcBound() {
+        DispatchHost host = getHost();
+        JobDetail job1 = getJob1();
+        JobDetail job2 = getJob2();
+        job1.priority = 100;
+        job2.priority = 200;
+
+        jobDao.updateMaxCores(job2, 0);
+        jobDao.updatePriority(job1, 100);
+        jobDao.updatePriority(job2, 200);
+
+        DispatchFrame frame = dispatcherDao.findNextDispatchFrame(job1, host);
+        assertNotNull(frame);
+
+        assertEquals(JobState.PENDING.toString(),
+                jdbcTemplate.queryForObject(
+                        "SELECT str_state FROM job WHERE pk_job=?",
+                        String.class, job1.id));
+
+        assertEquals(JobState.PENDING.toString(),
+                jdbcTemplate.queryForObject(
+                        "SELECT str_state FROM job WHERE pk_job=?",
+                        String.class, job2.id));
+
+        VirtualProc proc = VirtualProc.build(host, frame);
+        proc.coresReserved = 100;
+        dispatcher.dispatch(frame, proc);
+
+        boolean isHigher = dispatcherDao.higherPriorityJobExists(job1, proc);
+        assertFalse(isHigher);
     }
 }
-
-


### PR DESCRIPTION
Issue #298 
Update the dispatcher behavior to the following:

On Frame completion:
1. Check if any job is under it's `min_cores` setting, if there are dispatch those jobs
2. Check if any job is a higher priority, if so dispatch the highest priority job
3. Attempt to dispatch proc to same job.

On HostReport (no job currently running on the host):
1. Dispatch to a job under it's `min_core` setting.
2. Dispatch to the highest priority job if all jobs have hit their `min_core` target.