### PR TITLE
Adding default pyoutline home and user directories to the config

### DIFF
--- a/pyoutline/outline/config.py
+++ b/pyoutline/outline/config.py
@@ -35,8 +35,7 @@ __all__ = ["config"]
 __file_path__ = pathlib.Path(__file__)
 
 PYOUTLINE_ROOT_DIR = __file_path__.parent.parent
-DEFAULT_USER_DIR = pathlib.Path('{tmpdir}/opencue/outline/{user}'.format(
-    tmpdir=tempfile.gettempdir(), user=getpass.getuser()))
+DEFAULT_USER_DIR = pathlib.Path(tempfile.gettempdir()) / 'opencue' / 'outline' / getpass.getuser()
 
 config = SafeConfigParser()
 

--- a/pyoutline/outline/config.py
+++ b/pyoutline/outline/config.py
@@ -24,6 +24,7 @@ from future import standard_library
 standard_library.install_aliases()
 import getpass
 import os
+import tempfile
 
 from six.moves.configparser import SafeConfigParser
 
@@ -31,7 +32,7 @@ from six.moves.configparser import SafeConfigParser
 __all__ = ["config"]
 
 PYOUTLINE_ROOT_DIR = os.path.dirname(os.path.dirname(__file__))
-DEFAULT_USER_DIR = '/tmp/opencue/outline/user/{}'.format(getpass.getuser())
+DEFAULT_USER_DIR = '{}/opencue/outline/{}'.format(tempfile.gettempdir(), getpass.getuser())
 
 config = SafeConfigParser()
 

--- a/pyoutline/outline/config.py
+++ b/pyoutline/outline/config.py
@@ -22,12 +22,16 @@ from __future__ import absolute_import
 
 from future import standard_library
 standard_library.install_aliases()
+import getpass
 import os
 
 from six.moves.configparser import SafeConfigParser
 
 
 __all__ = ["config"]
+
+PYOUTLINE_ROOT_DIR = os.path.dirname(os.path.dirname(__file__))
+DEFAULT_USER_DIR = '/tmp/opencue/outline/user/{}'.format(getpass.getuser())
 
 config = SafeConfigParser()
 
@@ -45,3 +49,10 @@ for default_config_path in default_config_paths:
         break
 
 config.read(os.environ.get("OL_CONFIG", default_config_path))
+
+# Add defaults to the config,if they were not specified.
+if not config.get('outline', 'home'):
+    config.set('outline', 'home', PYOUTLINE_ROOT_DIR)
+
+if not config.get('outline', 'user_dir'):
+    config.set('outline', 'user_dir', DEFAULT_USER_DIR)

--- a/pyoutline/outline/config.py
+++ b/pyoutline/outline/config.py
@@ -20,40 +20,38 @@ from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
 
+from builtins import str
 from future import standard_library
 standard_library.install_aliases()
 import getpass
 import os
+import pathlib
 import tempfile
 
 from six.moves.configparser import SafeConfigParser
 
 
 __all__ = ["config"]
+__file_path__ = pathlib.Path(__file__)
 
-PYOUTLINE_ROOT_DIR = os.path.dirname(os.path.dirname(__file__))
-DEFAULT_USER_DIR = '{}/opencue/outline/{}'.format(tempfile.gettempdir(), getpass.getuser())
+PYOUTLINE_ROOT_DIR = __file_path__.parent.parent
+DEFAULT_USER_DIR = pathlib.Path('{tmpdir}/opencue/outline/{user}'.format(
+    tmpdir=tempfile.gettempdir(), user=getpass.getuser()))
 
 config = SafeConfigParser()
 
-default_config_paths = [
-    os.path.join(
-        os.path.dirname(os.path.dirname(os.path.dirname(__file__))),
-        'etc', 'outline.cfg'),
-    os.path.join(
-        os.path.dirname(os.path.dirname(__file__)),
-        'etc', 'outline.cfg'),
-]
+default_config_paths = [__file_path__.parent.parent.parent / 'etc' / 'outline.cfg',
+                        __file_path__.parent.parent / 'etc' / 'outline.cfg']
 default_config_path = None
 for default_config_path in default_config_paths:
-    if os.path.exists(default_config_path):
+    if default_config_path.exists():
         break
 
-config.read(os.environ.get("OL_CONFIG", default_config_path))
+config.read(os.environ.get("OL_CONFIG", str(default_config_path)))
 
 # Add defaults to the config,if they were not specified.
 if not config.get('outline', 'home'):
-    config.set('outline', 'home', PYOUTLINE_ROOT_DIR)
+    config.set('outline', 'home', str(PYOUTLINE_ROOT_DIR))
 
 if not config.get('outline', 'user_dir'):
-    config.set('outline', 'user_dir', DEFAULT_USER_DIR)
+    config.set('outline', 'user_dir', str(DEFAULT_USER_DIR))

--- a/pyoutline/tests/backend/cue_test.py
+++ b/pyoutline/tests/backend/cue_test.py
@@ -39,6 +39,8 @@ TEST_USER = 'test-user'
 class SerializeTest(unittest.TestCase):
     def testSerializeShellOutline(self):
         path = os.path.join(SCRIPTS_DIR, 'shell.outline')
+        outline.config.set('outline', 'home', '/opencue/outline')
+        outline.config.set('outline', 'user_dir', '/tmp/opencue/user')
         ol = outline.load_outline(path)
         launcher = outline.cuerun.OutlineLauncher(ol, user=TEST_USER)
 
@@ -65,8 +67,9 @@ class SerializeTest(unittest.TestCase):
         self.assertEqual('Render', layer.get('type'))
         self.assertEqual(1, len(layer.findall('cmd')))
         self.assertEqual(
-            '/wrappers/opencue_wrap_frame  '
-            '/bin/pycuerun '
+            '/opencue/outline/wrappers/opencue_wrap_frame '
+            '/tmp/opencue/user '
+            '/opencue/outline/bin/pycuerun '
             '{scripts_dir}/shell.outline '
             '-e #IFRAME#-cmd '
             '--version latest '
@@ -86,6 +89,8 @@ class SerializeTest(unittest.TestCase):
 class BuildCommandTest(unittest.TestCase):
     def setUp(self):
         path = os.path.join(SCRIPTS_DIR, 'shell.outline')
+        outline.config.set('outline', 'home', '')
+        outline.config.set('outline', 'user_dir', '')
         self.ol = outline.load_outline(path)
         self.launcher = outline.cuerun.OutlineLauncher(self.ol, user=TEST_USER)
         self.layer = self.ol.get_layer('cmd')

--- a/pyoutline/tests/backend/local_test.py
+++ b/pyoutline/tests/backend/local_test.py
@@ -33,6 +33,8 @@ SCRIPTS_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'scr
 class BuildCommandTest(unittest.TestCase):
     def setUp(self):
         path = os.path.join(SCRIPTS_DIR, 'shell.outline')
+        outline.config.set('outline', 'home', '')
+        outline.config.set('outline', 'user_dir', '')
         self.ol = outline.load_outline(path)
         self.launcher = outline.cuerun.OutlineLauncher(self.ol)
         self.layer = self.ol.get_layer('cmd')

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ futures==3.2.0;python_version<"3.0"
 grpcio==1.16.0
 grpcio-tools==1.16.0
 mock==2.0.0
+pathlib==1.0.1;python_version<"3.4"
 pexpect==4.6.0
 PySide2==5.11.2
 psutil==5.4.7


### PR DESCRIPTION
Related to #228 
The `home` and `user_dir` variables of the `outline.cfg` should be specified by the user. If they are not this change provides some defaults.