### PR TITLE
Cleanup spring xml files to all use schema definitions.

### DIFF
--- a/cuebot/src/main/resources/conf/spring/applicationContext-criteria.xml
+++ b/cuebot/src/main/resources/conf/spring/applicationContext-criteria.xml
@@ -16,14 +16,10 @@
 -->
 
 
-
-
-<beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xmlns:aop="http://www.springframework.org/schema/aop" xmlns:tx="http://www.springframework.org/schema/tx"
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xsi:schemaLocation="
-       http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.5.xsd
-       http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-2.5.xsd
-       http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-2.5.xsd">
+           http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.5.xsd">
 
     <bean id="frameSearchFactory" class="com.imageworks.spcue.dao.criteria.FrameSearchFactory">
         <property name="dbEngine" ref="dbEngine" />

--- a/cuebot/src/main/resources/conf/spring/applicationContext-dao-oracle.xml
+++ b/cuebot/src/main/resources/conf/spring/applicationContext-dao-oracle.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
 <!--
    Copyright (c) 2018 Sony Pictures Imageworks Inc.
 
@@ -17,128 +16,128 @@
 -->
 
 
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="
+            http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.5.xsd">
 
-<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN//EN" "http://www.springframework.org/dtd/spring-beans.dtd">
+    <bean id="transactionManager" class="org.springframework.jdbc.datasource.DataSourceTransactionManager">
+        <property name="dataSource" ref="cueDataSource" />
+    </bean>
 
-<beans>
+    <bean id="allocationDao" class="com.imageworks.spcue.dao.oracle.AllocationDaoJdbc">
+        <property name="dataSource" ref="cueDataSource" />
+    </bean>
 
-  <bean id="transactionManager" class="org.springframework.jdbc.datasource.DataSourceTransactionManager">
-    <property name="dataSource" ref="cueDataSource" />
-  </bean>
+    <bean id="subscriptionDao" class="com.imageworks.spcue.dao.oracle.SubscriptionDaoJdbc">
+        <property name="dataSource" ref="cueDataSource" />
+    </bean>
 
-  <bean id="allocationDao" class="com.imageworks.spcue.dao.oracle.AllocationDaoJdbc">
-    <property name="dataSource" ref="cueDataSource" />
-  </bean>
+    <bean id="showDao" class="com.imageworks.spcue.dao.oracle.ShowDaoJdbc">
+        <property name="dataSource" ref="cueDataSource" />
+    </bean>
 
-  <bean id="subscriptionDao" class="com.imageworks.spcue.dao.oracle.SubscriptionDaoJdbc">
-    <property name="dataSource" ref="cueDataSource" />
-  </bean>
+    <bean id="jobDao" class="com.imageworks.spcue.dao.oracle.JobDaoJdbc">
+        <property name="dataSource" ref="cueDataSource" />
+    </bean>
 
-  <bean id="showDao" class="com.imageworks.spcue.dao.oracle.ShowDaoJdbc">
-    <property name="dataSource" ref="cueDataSource" />
-  </bean>
+    <bean id="layerDao" class="com.imageworks.spcue.dao.oracle.LayerDaoJdbc">
+        <property name="dataSource" ref="cueDataSource" />
+    </bean>
 
-  <bean id="jobDao" class="com.imageworks.spcue.dao.oracle.JobDaoJdbc">
-    <property name="dataSource" ref="cueDataSource" />
-  </bean>
+    <bean id="frameDao" class="com.imageworks.spcue.dao.oracle.FrameDaoJdbc">
+        <property name="dataSource" ref="cueDataSource" />
+    </bean>
 
-  <bean id="layerDao" class="com.imageworks.spcue.dao.oracle.LayerDaoJdbc">
-    <property name="dataSource" ref="cueDataSource" />
-  </bean>
+    <bean id="hostDao" class="com.imageworks.spcue.dao.oracle.HostDaoJdbc">
+        <property name="dataSource" ref="cueDataSource" />
+    </bean>
 
-  <bean id="frameDao" class="com.imageworks.spcue.dao.oracle.FrameDaoJdbc">
-    <property name="dataSource" ref="cueDataSource" />
-  </bean>
+    <bean id="procDao" class="com.imageworks.spcue.dao.oracle.ProcDaoJdbc">
+        <property name="dataSource" ref="cueDataSource" />
+    </bean>
 
-  <bean id="hostDao" class="com.imageworks.spcue.dao.oracle.HostDaoJdbc">
-    <property name="dataSource" ref="cueDataSource" />
-  </bean>
+    <bean id="dependDao" class="com.imageworks.spcue.dao.oracle.DependDaoJdbc">
+        <property name="dataSource" ref="cueDataSource" />
+    </bean>
 
-  <bean id="procDao" class="com.imageworks.spcue.dao.oracle.ProcDaoJdbc">
-    <property name="dataSource" ref="cueDataSource" />
-  </bean>
+    <bean id="whiteboardDao" class="com.imageworks.spcue.dao.oracle.WhiteboardDaoJdbc">
+        <property name="dataSource" ref="cueDataSource" />
+        <property name="frameSearchFactory" ref="frameSearchFactory" />
+        <property name="procSearchFactory" ref="procSearchFactory" />
+    </bean>
 
-  <bean id="dependDao" class="com.imageworks.spcue.dao.oracle.DependDaoJdbc">
-    <property name="dataSource" ref="cueDataSource" />
-  </bean>
+    <bean id="nestedWhiteboardDao" class="com.imageworks.spcue.dao.oracle.NestedWhiteboardDaoJdbc">
+        <property name="dataSource" ref="cueDataSource" />
+    </bean>
 
-  <bean id="whiteboardDao" class="com.imageworks.spcue.dao.oracle.WhiteboardDaoJdbc">
-    <property name="dataSource" ref="cueDataSource" />
-    <property name="frameSearchFactory" ref="frameSearchFactory" />
-    <property name="procSearchFactory" ref="procSearchFactory" />
-  </bean>
+    <bean id="dispatcherDao" class="com.imageworks.spcue.dao.oracle.DispatcherDaoJdbc">
+        <property name="dataSource" ref="cueDataSource" />
+    </bean>
 
-  <bean id="nestedWhiteboardDao" class="com.imageworks.spcue.dao.oracle.NestedWhiteboardDaoJdbc">
-    <property name="dataSource" ref="cueDataSource" />
-  </bean>
+    <bean id="maintenanceDao" class="com.imageworks.spcue.dao.oracle.MaintenanceDaoJdbc">
+        <property name="dataSource" ref="cueDataSource" />
+    </bean>
 
-  <bean id="dispatcherDao" class="com.imageworks.spcue.dao.oracle.DispatcherDaoJdbc">
-    <property name="dataSource" ref="cueDataSource" />
-  </bean>
+    <bean id="filterDao" class="com.imageworks.spcue.dao.oracle.FilterDaoJdbc">
+        <property name="dataSource" ref="cueDataSource" />
+    </bean>
 
-  <bean id="maintenanceDao" class="com.imageworks.spcue.dao.oracle.MaintenanceDaoJdbc">
-    <property name="dataSource" ref="cueDataSource" />
-  </bean>
+    <bean id="actionDao" class="com.imageworks.spcue.dao.oracle.ActionDaoJdbc">
+        <property name="dataSource" ref="cueDataSource" />
+    </bean>
 
-  <bean id="filterDao" class="com.imageworks.spcue.dao.oracle.FilterDaoJdbc">
-    <property name="dataSource" ref="cueDataSource" />
-  </bean>
+    <bean id="matcherDao" class="com.imageworks.spcue.dao.oracle.MatcherDaoJdbc">
+        <property name="dataSource" ref="cueDataSource" />
+    </bean>
 
-  <bean id="actionDao" class="com.imageworks.spcue.dao.oracle.ActionDaoJdbc">
-    <property name="dataSource" ref="cueDataSource" />
-  </bean>
+    <bean id="groupDao" class="com.imageworks.spcue.dao.oracle.GroupDaoJdbc">
+        <property name="dataSource" ref="cueDataSource" />
+    </bean>
 
-  <bean id="matcherDao" class="com.imageworks.spcue.dao.oracle.MatcherDaoJdbc">
-    <property name="dataSource" ref="cueDataSource" />
-  </bean>
+    <bean id="commentDao" class="com.imageworks.spcue.dao.oracle.CommentDaoJdbc">
+        <property name="dataSource" ref="cueDataSource" />
+    </bean>
 
-  <bean id="groupDao" class="com.imageworks.spcue.dao.oracle.GroupDaoJdbc">
-    <property name="dataSource" ref="cueDataSource" />
-  </bean>
+    <bean id="historicalDao" class="com.imageworks.spcue.dao.oracle.HistoricalDaoJdbc">
+        <property name="dataSource" ref="cueDataSource" />
+    </bean>
 
-  <bean id="commentDao" class="com.imageworks.spcue.dao.oracle.CommentDaoJdbc">
-    <property name="dataSource" ref="cueDataSource" />
-  </bean>
+    <bean id="facilityDao" class="com.imageworks.spcue.dao.oracle.FacilityDaoJdbc">
+        <property name="dataSource" ref="cueDataSource" />
+    </bean>
 
-  <bean id="historicalDao" class="com.imageworks.spcue.dao.oracle.HistoricalDaoJdbc">
-    <property name="dataSource" ref="cueDataSource" />
-  </bean>
+    <bean id="departmentDao" class="com.imageworks.spcue.dao.oracle.DepartmentDaoJdbc">
+        <property name="dataSource" ref="cueDataSource" />
+    </bean>
 
-  <bean id="facilityDao" class="com.imageworks.spcue.dao.oracle.FacilityDaoJdbc">
-    <property name="dataSource" ref="cueDataSource" />
-  </bean>
+    <bean id="taskDao" class="com.imageworks.spcue.dao.oracle.TaskDaoJdbc">
+        <property name="dataSource" ref="cueDataSource" />
+    </bean>
 
-  <bean id="departmentDao" class="com.imageworks.spcue.dao.oracle.DepartmentDaoJdbc">
-    <property name="dataSource" ref="cueDataSource" />
-  </bean>
+    <bean id="pointDao" class="com.imageworks.spcue.dao.oracle.PointDaoJdbc">
+        <property name="dataSource" ref="cueDataSource" />
+    </bean>
 
-  <bean id="taskDao" class="com.imageworks.spcue.dao.oracle.TaskDaoJdbc">
-    <property name="dataSource" ref="cueDataSource" />
-  </bean>
+    <bean id="ownerDao" class="com.imageworks.spcue.dao.oracle.OwnerDaoJdbc">
+        <property name="dataSource" ref="cueDataSource" />
+    </bean>
 
-  <bean id="pointDao" class="com.imageworks.spcue.dao.oracle.PointDaoJdbc">
-    <property name="dataSource" ref="cueDataSource" />
-  </bean>
+    <bean id="deedDao" class="com.imageworks.spcue.dao.oracle.DeedDaoJdbc">
+        <property name="dataSource" ref="cueDataSource" />
+    </bean>
 
-  <bean id="ownerDao" class="com.imageworks.spcue.dao.oracle.OwnerDaoJdbc">
-    <property name="dataSource" ref="cueDataSource" />
-  </bean>
+    <bean id="serviceDao" class="com.imageworks.spcue.dao.oracle.ServiceDaoJdbc">
+        <property name="dataSource" ref="cueDataSource" />
+    </bean>
 
-  <bean id="deedDao" class="com.imageworks.spcue.dao.oracle.DeedDaoJdbc">
-    <property name="dataSource" ref="cueDataSource" />
-  </bean>
+    <bean id="bookingDao" class="com.imageworks.spcue.dao.oracle.BookingDaoJdbc">
+        <property name="dataSource" ref="cueDataSource" />
+    </bean>
 
-  <bean id="serviceDao" class="com.imageworks.spcue.dao.oracle.ServiceDaoJdbc">
-    <property name="dataSource" ref="cueDataSource" />
-  </bean>
-
-  <bean id="bookingDao" class="com.imageworks.spcue.dao.oracle.BookingDaoJdbc">
-    <property name="dataSource" ref="cueDataSource" />
-  </bean>
-
-  <bean id="redirectDao" class="com.imageworks.spcue.dao.oracle.RedirectDaoJdbc">
-    <property name="dataSource" ref="cueDataSource" />
-  </bean>
+    <bean id="redirectDao" class="com.imageworks.spcue.dao.oracle.RedirectDaoJdbc">
+        <property name="dataSource" ref="cueDataSource" />
+    </bean>
 
 </beans>
 

--- a/cuebot/src/main/resources/conf/spring/applicationContext-dao-postgres.xml
+++ b/cuebot/src/main/resources/conf/spring/applicationContext-dao-postgres.xml
@@ -16,11 +16,10 @@
 -->
 
 
-
-
-<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN//EN" "http://www.springframework.org/dtd/spring-beans.dtd">
-
-<beans>
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="
+            http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.5.xsd">
     
     <bean id="transactionManager" class="org.springframework.jdbc.datasource.DataSourceTransactionManager">
         <property name="dataSource" ref="cueDataSource"/>

--- a/cuebot/src/main/resources/conf/spring/applicationContext-dbEngine.xml
+++ b/cuebot/src/main/resources/conf/spring/applicationContext-dbEngine.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
 <!--
    Copyright (c) 2018 Sony Pictures Imageworks Inc.
 
@@ -19,7 +18,8 @@
 
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+       xsi:schemaLocation="
+            http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.5.xsd">
 
     <bean id="dbEngine" class="com.imageworks.spcue.config.DatabaseEngine" factory-method="fromEnv"
           lazy-init="false"/>

--- a/cuebot/src/main/resources/conf/spring/applicationContext-grpc.xml
+++ b/cuebot/src/main/resources/conf/spring/applicationContext-grpc.xml
@@ -15,9 +15,11 @@
    limitations under the License.
 -->
 
-<beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xsi:schemaLocation="
-       http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+            http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.5.xsd">
 
     <bean id="cueStaticServant" class="com.imageworks.spcue.servant.CueStatic">
         <property name="whiteboard" ref="whiteboard" />

--- a/cuebot/src/main/resources/conf/spring/applicationContext-grpcServer.xml
+++ b/cuebot/src/main/resources/conf/spring/applicationContext-grpcServer.xml
@@ -16,15 +16,16 @@
 -->
 
 
-<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN//EN" "http://www.springframework.org/dtd/spring-beans.dtd">
-<beans>
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="
+            http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.5.xsd">
 
     <bean id="propertyConfigurer" class="org.springframework.beans.factory.config.PropertyPlaceholderConfigurer">
         <property name="location">
             <value>opencue.properties</value>
         </property>
     </bean>
-
 
     <!--Run -->
     <bean id="manageGrpcServer" class="com.imageworks.common.spring.remoting.GrpcServer" init-method="start" destroy-method="shutdown">

--- a/cuebot/src/main/resources/conf/spring/applicationContext-jms.xml
+++ b/cuebot/src/main/resources/conf/spring/applicationContext-jms.xml
@@ -16,10 +16,9 @@
 -->
 
 
-
-
-<beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="
          http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.5.xsd">
 
   <bean id="jmsFactory"

--- a/cuebot/src/main/resources/conf/spring/applicationContext-service.xml
+++ b/cuebot/src/main/resources/conf/spring/applicationContext-service.xml
@@ -16,14 +16,11 @@
 -->
 
 
-
-
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xmlns:aop="http://www.springframework.org/schema/aop" xmlns:tx="http://www.springframework.org/schema/tx"
-  xsi:schemaLocation="
-       http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.5.xsd
-       http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-2.5.xsd
-       http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-2.5.xsd">
+       xmlns:tx="http://www.springframework.org/schema/tx"
+       xsi:schemaLocation="
+         http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.5.xsd
+         http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-2.5.xsd">
 
   <!--
     Enables annotation driven Transaction setup. Any class you want to be Transactional must have a

--- a/cuebot/src/main/resources/conf/spring/applicationContext-trackit.xml
+++ b/cuebot/src/main/resources/conf/spring/applicationContext-trackit.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
 <!--
    Copyright (c) 2018 Sony Pictures Imageworks Inc.
 
@@ -17,10 +16,10 @@
 -->
 
 
-
-<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN//EN" "http://www.springframework.org/dtd/spring-beans.dtd">
-
-<beans>
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="
+            http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.5.xsd">
 
     <bean id="trackitDao" class="com.imageworks.spcue.dao.oracle.TrackitDaoJdbc">
         <property name="dataSource" ref="trackitDataSource"/>

--- a/cuebot/src/main/resources/conf/spring/jobLaunchServlet-servlet.xml
+++ b/cuebot/src/main/resources/conf/spring/jobLaunchServlet-servlet.xml
@@ -16,11 +16,9 @@
 -->
 
 
-
-
-<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN//EN"
-"http://www.springframework.org/dtd/spring-beans.dtd">
-<beans>
-
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="
+            http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.5.xsd">
 
 </beans>

--- a/cuebot/src/test/resources/conf/spring/applicationContext-assumptions.xml
+++ b/cuebot/src/test/resources/conf/spring/applicationContext-assumptions.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
 <!--
    Copyright (c) 2018 Sony Pictures Imageworks Inc.
 
@@ -19,7 +18,8 @@
 
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+       xsi:schemaLocation="
+            http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.5.xsd">
 
     <bean id="assumingOracleEngine" class="com.imageworks.spcue.test.AssumingOracleEngine">
         <property name="dbEngine" ref="dbEngine" />

--- a/cuebot/src/test/resources/conf/spring/applicationContext-grpcServer.xml
+++ b/cuebot/src/test/resources/conf/spring/applicationContext-grpcServer.xml
@@ -16,8 +16,10 @@
 -->
 
 
-<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN//EN" "http://www.springframework.org/dtd/spring-beans.dtd">
-<beans>
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="
+            http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.5.xsd">
 
     <bean id="propertyConfigurer" class="org.springframework.beans.factory.config.PropertyPlaceholderConfigurer">
         <property name="location">

--- a/cuebot/src/test/resources/conf/spring/applicationContext-oracle-datasource.xml
+++ b/cuebot/src/test/resources/conf/spring/applicationContext-oracle-datasource.xml
@@ -18,14 +18,10 @@
 
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xmlns:aop="http://www.springframework.org/schema/aop"
-       xmlns:tx="http://www.springframework.org/schema/tx"
        xmlns:util="http://www.springframework.org/schema/util"
        xsi:schemaLocation="
-       http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.5.xsd
-       http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-2.5.xsd
-       http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-2.5.xsd
-       http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-2.5.xsd">
+           http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.5.xsd
+           http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-2.5.xsd">
     
     <!--
     The way the unit tests work right now, any test that has this XML included will set up the entire context from scratch for the

--- a/cuebot/src/test/resources/conf/spring/applicationContext-postgres-datasource.xml
+++ b/cuebot/src/test/resources/conf/spring/applicationContext-postgres-datasource.xml
@@ -18,14 +18,10 @@
 
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xmlns:aop="http://www.springframework.org/schema/aop"
-       xmlns:tx="http://www.springframework.org/schema/tx"
        xmlns:util="http://www.springframework.org/schema/util"
        xsi:schemaLocation="
-       http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.5.xsd
-       http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-2.5.xsd
-       http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-2.5.xsd
-       http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-2.5.xsd">
+           http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.5.xsd
+           http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-2.5.xsd">
 
     <!--
     The way the unit tests work right now, any test that has this XML included will set up the entire context from scratch for the


### PR DESCRIPTION
Lock all xml schemas to 2.5 until we upgrade spring versions #235.
As part of moving to spring 5.1 we should remove the schema version from the urls.