### PR TITLE
Adding unittests for group and host wrappers.

### DIFF
--- a/cuebot/src/main/java/com/imageworks/spcue/servant/ManageHost.java
+++ b/cuebot/src/main/java/com/imageworks/spcue/servant/ManageHost.java
@@ -181,7 +181,7 @@ public class ManageHost extends HostInterfaceGrpc.HostInterfaceImplBase {
                               StreamObserver<HostSetAllocationResponse> responseObserver) {
         HostInterface host = getHostInterface(request.getHost());
         hostManager.setAllocation(host,
-                adminManager.getAllocationDetail(request.getAllocationName()));
+                adminManager.getAllocationDetail(request.getAllocationId()));
         responseObserver.onNext(HostSetAllocationResponse.newBuilder().build());
         responseObserver.onCompleted();
     }

--- a/cuegui/cuegui/MenuActions.py
+++ b/cuegui/cuegui/MenuActions.py
@@ -1123,8 +1123,7 @@ class GroupActions(AbstractActions):
                 for group in groups:
                     if isinstance(group, opencue.wrappers.group.NestedGroup):
                         group = group.asGroup()
-                    self.cuebotCall(opencue.wrappers.group.Group(group).delete,
-                                    "Delete Group %s Failed" % group.name)
+                    self.cuebotCall(group.delete, "Delete Group {} Failed".format(group.name()))
 
 
 class SubscriptionActions(AbstractActions):

--- a/proto/host.proto
+++ b/proto/host.proto
@@ -612,7 +612,7 @@ message HostRenameTagResponse {} // Empty
 // SetAllocation
 message HostSetAllocationRequest {
     Host host = 1;
-    string allocation_name = 2;
+    string allocation_id = 2;
 }
 
 message HostSetAllocationResponse {} // Empty

--- a/pycue/opencue/wrappers/group.py
+++ b/pycue/opencue/wrappers/group.py
@@ -186,7 +186,7 @@ class NestedGroup(Group):
 
     def createSubGroup(self, name):
         """Create a sub group"""
-        return Group(self.asGroup()).createSubGroup(name)
+        return self.asGroup().createSubGroup(name)
 
     def children(self):
         """returns jobs and groups in a single array"""
@@ -198,7 +198,7 @@ class NestedGroup(Group):
 
     def asGroup(self):
         """returns a Group object from this NestedGroup"""
-        return job_pb2.Group(
+        return Group(job_pb2.Group(
             id=self.data.id,
             name=self.data.name,
             department=self.data.department,
@@ -209,4 +209,4 @@ class NestedGroup(Group):
             max_cores=self.data.max_cores,
             level=self.data.level,
             group_stats=self.data.stats,
-        )
+        ))

--- a/pycue/opencue/wrappers/host.py
+++ b/pycue/opencue/wrappers/host.py
@@ -115,7 +115,7 @@ class Host(object):
         @param allocation: An allocation object
         """
         self.stub.SetAllocation(
-            host_pb2.HostSetAllocationRequest(host=self.data, allocation_name=allocation.id()),
+            host_pb2.HostSetAllocationRequest(host=self.data, allocation_id=allocation.id()),
             timeout=Cuebot.Timeout)
 
     def addComment(self, subject, message):
@@ -149,11 +149,11 @@ class Host(object):
             host_pb2.HostSetHardwareStateRequest(host=self.data, state=state),
             timeout=Cuebot.Timeout)
 
-    def setOs(self, os):
+    def setOs(self, osName):
         """Sets the host os
-        @type os: string
-        @param os: os value to set host to"""
-        self.stub.SetOs(host_pb2.HostSetOsRequest(host=self.data, os=os),
+        @type osName: string
+        @param osName: os value to set host to"""
+        self.stub.SetOs(host_pb2.HostSetOsRequest(host=self.data, os=osName),
                         timeout=Cuebot.Timeout)
 
     def setThreadMode(self, mode):

--- a/pycue/tests/wrappers/group_test.py
+++ b/pycue/tests/wrappers/group_test.py
@@ -1,0 +1,261 @@
+#!/usr/bin/env python
+
+#  Copyright (c) 2018 Sony Pictures Imageworks Inc.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+import mock
+import unittest
+
+import opencue
+from opencue.compiled_proto import job_pb2
+
+
+TEST_GROUP_NAME = 'testGroup'
+
+
+@mock.patch('opencue.cuebot.Cuebot.getStub')
+class GroupTests(unittest.TestCase):
+
+    def testCreateSubGroup(self, getStubMock):
+        subgroupName = 'testSubgroup'
+        stubMock = mock.Mock()
+        stubMock.CreateSubGroup.return_value = job_pb2.GroupCreateSubGroupResponse(
+            group=job_pb2.Group(name=subgroupName))
+        getStubMock.return_value = stubMock
+
+        group = opencue.wrappers.group.Group(
+            job_pb2.Group(name=TEST_GROUP_NAME))
+        subgroup = group.createSubGroup(subgroupName)
+
+        stubMock.CreateSubGroup.assert_called_with(
+            job_pb2.GroupCreateSubGroupRequest(group=group.data, name=subgroupName),
+            timeout=mock.ANY)
+        self.assertEqual(subgroup.name(), subgroupName)
+
+    def testDelete(self, getStubMock):
+        stubMock = mock.Mock()
+        stubMock.Delete.return_value = job_pb2.GroupDeleteResponse()
+        getStubMock.return_value = stubMock
+
+        group = opencue.wrappers.group.Group(
+            job_pb2.Group(name=TEST_GROUP_NAME))
+        group.delete()
+
+        stubMock.Delete.assert_called_with(
+            job_pb2.GroupDeleteRequest(group=group.data),
+            timeout=mock.ANY)
+
+    def testSetName(self, getStubMock):
+        stubMock = mock.Mock()
+        stubMock.SetName.return_value = job_pb2.GroupSetNameResponse()
+        getStubMock.return_value = stubMock
+
+        newName = 'changedName'
+        group = opencue.wrappers.group.Group(
+            job_pb2.Group(name=TEST_GROUP_NAME))
+        group.setName(newName)
+
+        stubMock.SetName.assert_called_with(
+            job_pb2.GroupSetNameRequest(group=group.data, name=newName),
+            timeout=mock.ANY)
+
+    def testSetMaxCores(self, getStubMock):
+        stubMock = mock.Mock()
+        stubMock.SetMaxCores.return_value = job_pb2.GroupSetMaxCoresResponse()
+        getStubMock.return_value = stubMock
+
+        value = 523
+        group = opencue.wrappers.group.Group(
+            job_pb2.Group(name=TEST_GROUP_NAME))
+        group.setMaxCores(value)
+
+        stubMock.SetMaxCores.assert_called_with(
+            job_pb2.GroupSetMaxCoresRequest(group=group.data, max_cores=value),
+            timeout=mock.ANY)
+
+    def testSetMinCores(self, getStubMock):
+        stubMock = mock.Mock()
+        stubMock.SetMinCores.return_value = job_pb2.GroupSetMinCoresResponse()
+        getStubMock.return_value = stubMock
+
+        value = 2
+        group = opencue.wrappers.group.Group(
+            job_pb2.Group(name=TEST_GROUP_NAME))
+        group.setMinCores(value)
+
+        stubMock.SetMinCores.assert_called_with(
+            job_pb2.GroupSetMinCoresRequest(group=group.data, min_cores=value),
+            timeout=mock.ANY)
+
+    def testSetDefaultJobPriority(self, getStubMock):
+        stubMock = mock.Mock()
+        stubMock.SetDefaultJobPriority.return_value = job_pb2.GroupSetDefJobPriorityResponse()
+        getStubMock.return_value = stubMock
+
+        value = 500
+        group = opencue.wrappers.group.Group(
+            job_pb2.Group(name=TEST_GROUP_NAME))
+        group.setDefaultJobPriority(value)
+
+        stubMock.SetDefaultJobPriority.assert_called_with(
+            job_pb2.GroupSetDefJobPriorityRequest(group=group.data, priority=value),
+            timeout=mock.ANY)
+
+    def testSetDefaultJobMaxCores(self, getStubMock):
+        stubMock = mock.Mock()
+        stubMock.SetDefaultJobMaxCores.return_value = job_pb2.GroupSetDefJobMaxCoresResponse()
+        getStubMock.return_value = stubMock
+
+        value = 523
+        group = opencue.wrappers.group.Group(
+            job_pb2.Group(name=TEST_GROUP_NAME))
+        group.setDefaultJobMaxCores(value)
+
+        stubMock.SetDefaultJobMaxCores.assert_called_with(
+            job_pb2.GroupSetDefJobMaxCoresRequest(group=group.data, max_cores=value),
+            timeout=mock.ANY)
+
+    def testSetDefaultJobMinCores(self, getStubMock):
+        stubMock = mock.Mock()
+        stubMock.SetDefaultJobMinCores.return_value = job_pb2.GroupSetDefJobMinCoresResponse()
+        getStubMock.return_value = stubMock
+
+        value = 2
+        group = opencue.wrappers.group.Group(
+            job_pb2.Group(name=TEST_GROUP_NAME))
+        group.setDefaultJobMinCores(value)
+
+        stubMock.SetDefaultJobMinCores.assert_called_with(
+            job_pb2.GroupSetDefJobMinCoresRequest(group=group.data, min_cores=value),
+            timeout=mock.ANY)
+
+    def testGetGroups(self, getStubMock):
+        stubMock = mock.Mock()
+        stubMock.GetGroups.return_value = job_pb2.GroupGetGroupsResponse(
+            groups=job_pb2.GroupSeq(groups=[job_pb2.Group(name=TEST_GROUP_NAME)]))
+        getStubMock.return_value = stubMock
+
+        group = opencue.wrappers.group.Group(
+            job_pb2.Group(name=TEST_GROUP_NAME))
+        groups = group.getGroups()
+
+        stubMock.GetGroups.assert_called_with(
+            job_pb2.GroupGetGroupsRequest(group=group.data),
+            timeout=mock.ANY)
+        self.assertEqual(len(groups), 1)
+        self.assertEqual(groups[0].name(), TEST_GROUP_NAME)
+
+    def testGetJobs(self, getStubMock):
+        jobName = 'testJob'
+        stubMock = mock.Mock()
+        stubMock.GetJobs.return_value = job_pb2.GroupGetJobsResponse(
+            jobs=job_pb2.JobSeq(jobs=[job_pb2.Job(name=jobName)]))
+        getStubMock.return_value = stubMock
+
+        group = opencue.wrappers.group.Group(
+            job_pb2.Group(name=TEST_GROUP_NAME))
+        jobs = group.getJobs()
+
+        stubMock.GetJobs.assert_called_with(
+            job_pb2.GroupGetJobsRequest(group=group.data),
+            timeout=mock.ANY)
+        self.assertEqual(len(jobs), 1)
+        self.assertEqual(jobs[0].name(), jobName)
+
+    def testReparentJobs(self, getStubMock):
+        stubMock = mock.Mock()
+        stubMock.ReparentJobs.return_value = job_pb2.GroupReparentJobsResponse()
+        getStubMock.return_value = stubMock
+
+        testJob = job_pb2.Job(name='testJob')
+        testNestedJob = job_pb2.NestedJob(name='testNestedJob')
+        jobs = [opencue.wrappers.job.Job(testJob), opencue.wrappers.job.NestedJob(testNestedJob)]
+        group = opencue.wrappers.group.Group(
+            job_pb2.Group(name=TEST_GROUP_NAME))
+        group.reparentJobs(jobs)
+
+        expected = job_pb2.JobSeq(jobs=[job_pb2.Job(name='testJob'),
+                                        job_pb2.Job(name='testNestedJob',
+                                                    job_stats=job_pb2.JobStats())])
+        stubMock.ReparentJobs.assert_called_with(
+            job_pb2.GroupReparentJobsRequest(group=group.data, jobs=expected),
+            timeout=mock.ANY)
+
+    def testReparentGroups(self, getStubMock):
+        stubMock = mock.Mock()
+        stubMock.ReparentGroups.return_value = job_pb2.GroupReparentGroupsResponse()
+        getStubMock.return_value = stubMock
+
+        groups = [job_pb2.Group()]
+        groupSeq = job_pb2.GroupSeq(groups=groups)
+        group = opencue.wrappers.group.Group(
+            job_pb2.Group(name=TEST_GROUP_NAME))
+        group.reparentGroups(groups)
+
+        stubMock.ReparentGroups.assert_called_with(
+            job_pb2.GroupReparentGroupsRequest(group=group.data, groups=groupSeq),
+            timeout=mock.ANY)
+
+    def testSetDepartment(self, getStubMock):
+        stubMock = mock.Mock()
+        stubMock.SetDepartment.return_value = job_pb2.GroupSetDeptResponse()
+        getStubMock.return_value = stubMock
+
+        dept = 'pipeline'
+        group = opencue.wrappers.group.Group(
+            job_pb2.Group(name=TEST_GROUP_NAME))
+        group.setDepartment(dept)
+
+        expected = job_pb2.Group(name=TEST_GROUP_NAME)
+        stubMock.SetDepartment.assert_called_with(
+            job_pb2.GroupSetDeptRequest(group=expected, dept=dept),
+            timeout=mock.ANY)
+
+    def testSetGroup(self, getStubMock):
+        stubMock = mock.Mock()
+        stubMock.SetGroup.return_value = job_pb2.GroupSetGroupResponse()
+        getStubMock.return_value = stubMock
+
+        parentGroup = job_pb2.Group(name='parentGroup')
+        group = opencue.wrappers.group.Group(
+            job_pb2.Group(name=TEST_GROUP_NAME))
+        group.setGroup(parentGroup)
+
+        stubMock.SetGroup.assert_called_with(
+            job_pb2.GroupSetGroupRequest(group=group.data, parent_group=parentGroup),
+            timeout=mock.ANY)
+
+
+@mock.patch('opencue.cuebot.Cuebot.getStub')
+class NestedGroupTests(unittest.TestCase):
+
+    def testAsGroup(self, getStubMock):
+        nestedGroup = opencue.wrappers.group.NestedGroup(job_pb2.NestedGroup(
+            id='ngn-ngng-ngn',
+            name='testNestedGroup',
+            department='pipeline'
+        ))
+        group = nestedGroup.asGroup()
+        self.assertEqual(nestedGroup.data.id, group.data.id)
+        self.assertEqual(nestedGroup.data.name, group.data.name)
+        self.assertEqual(nestedGroup.data.department, group.data.department)
+
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/pycue/tests/wrappers/host_test.py
+++ b/pycue/tests/wrappers/host_test.py
@@ -1,0 +1,276 @@
+#!/usr/bin/env python
+
+#  Copyright (c) 2018 Sony Pictures Imageworks Inc.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+import os
+import mock
+import unittest
+
+import opencue
+from opencue.compiled_proto import comment_pb2
+from opencue.compiled_proto import facility_pb2
+from opencue.compiled_proto import host_pb2
+from opencue.compiled_proto import renderPartition_pb2
+
+
+TEST_HOST_NAME = 'testHost'
+
+
+@mock.patch('opencue.cuebot.Cuebot.getStub')
+class HostTests(unittest.TestCase):
+
+    def testLock(self, getStubMock):
+        stubMock = mock.Mock()
+        stubMock.Lock.return_value = host_pb2.HostLockResponse()
+        getStubMock.return_value = stubMock
+
+        host = opencue.wrappers.host.Host(
+            host_pb2.Host(name=TEST_HOST_NAME))
+        host.lock()
+
+        stubMock.Lock.assert_called_with(
+            host_pb2.HostLockRequest(host=host.data),
+            timeout=mock.ANY)
+
+    def testUnlock(self, getStubMock):
+        stubMock = mock.Mock()
+        stubMock.Unlock.return_value = host_pb2.HostUnlockResponse()
+        getStubMock.return_value = stubMock
+
+        host = opencue.wrappers.host.Host(
+            host_pb2.Host(name=TEST_HOST_NAME))
+        host.unlock()
+
+        stubMock.Unlock.assert_called_with(
+            host_pb2.HostUnlockRequest(host=host.data),
+            timeout=mock.ANY)
+
+    def testDelete(self, getStubMock):
+        stubMock = mock.Mock()
+        stubMock.Delete.return_value = host_pb2.HostDeleteResponse()
+        getStubMock.return_value = stubMock
+
+        host = opencue.wrappers.host.Host(
+            host_pb2.Host(name=TEST_HOST_NAME))
+        host.delete()
+
+        stubMock.Delete.assert_called_with(
+            host_pb2.HostDeleteRequest(host=host.data),
+            timeout=mock.ANY)
+
+    def testGetProcs(self, getStubMock):
+        procName = 'testProc'
+        stubMock = mock.Mock()
+        stubMock.GetProcs.return_value = host_pb2.HostGetProcsResponse(
+            procs=host_pb2.ProcSeq(procs=[host_pb2.Proc(name=procName)]))
+        getStubMock.return_value = stubMock
+
+        host = opencue.wrappers.host.Host(
+            host_pb2.Host(name=TEST_HOST_NAME))
+        procs = host.getProcs()
+
+        stubMock.GetProcs.assert_called_with(
+            host_pb2.HostGetProcsRequest(host=host.data),
+            timeout=mock.ANY)
+        self.assertEqual(len(procs), 1)
+        self.assertEqual(procs[0].name(), procName)
+
+    def testGetRenderPartitions(self, getStubMock):
+        renderPartId = 'rpr-rprp-rpr'
+        stubMock = mock.Mock()
+        stubMock.GetRenderPartitions.return_value = host_pb2.HostGetRenderPartitionsResponse(
+            render_partitions=renderPartition_pb2.RenderPartitionSeq(
+                render_partitions=[renderPartition_pb2.RenderPartition(id=renderPartId)]))
+        getStubMock.return_value = stubMock
+
+        host = opencue.wrappers.host.Host(
+            host_pb2.Host(name=TEST_HOST_NAME))
+        renderParts = host.getRenderPartitions()
+
+        stubMock.GetRenderPartitions.assert_called_with(
+            host_pb2.HostGetRenderPartitionsRequest(host=host.data),
+            timeout=mock.ANY)
+        self.assertEqual(len(renderParts), 1)
+        self.assertEqual(renderParts[0].id, renderPartId)
+
+    def testRebootWhenIdle(self, getStubMock):
+        stubMock = mock.Mock()
+        stubMock.RebootWhenIdle.return_value = host_pb2.HostRebootWhenIdleResponse()
+        getStubMock.return_value = stubMock
+
+        host = opencue.wrappers.host.Host(
+            host_pb2.Host(name=TEST_HOST_NAME))
+        host.rebootWhenIdle()
+
+        stubMock.RebootWhenIdle.assert_called_with(
+            host_pb2.HostRebootWhenIdleRequest(host=host.data),
+            timeout=mock.ANY)
+
+    def testReboot(self, getStubMock):
+        stubMock = mock.Mock()
+        stubMock.Reboot.return_value = host_pb2.HostRebootResponse()
+        getStubMock.return_value = stubMock
+
+        host = opencue.wrappers.host.Host(
+            host_pb2.Host(name=TEST_HOST_NAME))
+        host.reboot()
+
+        stubMock.Reboot.assert_called_with(
+            host_pb2.HostRebootRequest(host=host.data),
+            timeout=mock.ANY)
+
+    def testAddTags(self, getStubMock):
+        stubMock = mock.Mock()
+        stubMock.AddTags.return_value = host_pb2.HostAddTagsResponse()
+        getStubMock.return_value = stubMock
+
+        tags = ['tags', 'are', 'fun']
+        host = opencue.wrappers.host.Host(
+            host_pb2.Host(name=TEST_HOST_NAME))
+        host.addTags(tags)
+
+        stubMock.AddTags.assert_called_with(
+            host_pb2.HostAddTagsRequest(host=host.data, tags=tags),
+            timeout=mock.ANY)
+
+    def testRemoveTags(self, getStubMock):
+        stubMock = mock.Mock()
+        stubMock.RemoveTags.return_value = host_pb2.HostRemoveTagsResponse()
+        getStubMock.return_value = stubMock
+
+        tags = ['tags', 'are', 'fun']
+        host = opencue.wrappers.host.Host(
+            host_pb2.Host(name=TEST_HOST_NAME))
+        host.removeTags(tags)
+
+        stubMock.RemoveTags.assert_called_with(
+            host_pb2.HostRemoveTagsRequest(host=host.data, tags=tags),
+            timeout=mock.ANY)
+
+    def testRenameTag(self, getStubMock):
+        stubMock = mock.Mock()
+        stubMock.RenameTag.return_value = host_pb2.HostRenameTagResponse()
+        getStubMock.return_value = stubMock
+
+        oldTag = 'sad'
+        newTag = 'happy'
+        host = opencue.wrappers.host.Host(
+            host_pb2.Host(name=TEST_HOST_NAME))
+        host.renameTag(oldTag, newTag)
+
+        stubMock.RenameTag.assert_called_with(
+            host_pb2.HostRenameTagRequest(host=host.data, old_tag=oldTag, new_tag=newTag),
+            timeout=mock.ANY)
+
+    def testSetAllocation(self, getStubMock):
+        stubMock = mock.Mock()
+        stubMock.SetAllocation.return_value = host_pb2.HostSetAllocationResponse()
+        getStubMock.return_value = stubMock
+
+        allocId = 'aaa-aaaa-aaa'
+        alloc = opencue.wrappers.allocation.Allocation(facility_pb2.Allocation(id=allocId))
+        host = opencue.wrappers.host.Host(
+            host_pb2.Host(name=TEST_HOST_NAME))
+        host.setAllocation(alloc)
+
+        stubMock.SetAllocation.assert_called_with(
+            host_pb2.HostSetAllocationRequest(host=host.data, allocation_id=alloc.id()),
+            timeout=mock.ANY)
+
+    def testAddComment(self, getStubMock):
+        stubMock = mock.Mock()
+        stubMock.AddComment.return_value = host_pb2.HostAddCommentResponse()
+        getStubMock.return_value = stubMock
+
+        subject = 'test'
+        message = 'this is a test.'
+        comment = comment_pb2.Comment(user=os.getenv("USER", "unknown"),
+                                      subject=subject,
+                                      message=message,
+                                      timestamp=0)
+        host = opencue.wrappers.host.Host(
+            host_pb2.Host(name=TEST_HOST_NAME))
+        host.addComment(subject, message)
+
+        stubMock.AddComment.assert_called_with(
+            host_pb2.HostAddCommentRequest(host=host.data, new_comment=comment),
+            timeout=mock.ANY)
+
+    def testGetComments(self, getStubMock):
+        message = 'this is a test.'
+        stubMock = mock.Mock()
+        stubMock.GetComments.return_value = host_pb2.HostGetCommentsResponse(
+            comments=comment_pb2.CommentSeq(comments=[comment_pb2.Comment(message=message)]))
+        getStubMock.return_value = stubMock
+
+        host = opencue.wrappers.host.Host(
+            host_pb2.Host(name=TEST_HOST_NAME))
+        comments = host.getComments()
+
+        stubMock.GetComments.assert_called_with(
+            host_pb2.HostGetCommentsRequest(host=host.data),
+            timeout=mock.ANY)
+        self.assertEqual(len(comments), 1)
+        self.assertEqual(comments[0].message(), message)
+
+    def testSetHardwareState(self, getStubMock):
+        stubMock = mock.Mock()
+        stubMock.SetHardwareState.return_value = host_pb2.HostSetHardwareStateResponse()
+        getStubMock.return_value = stubMock
+
+        state = host_pb2.REBOOTING
+        host = opencue.wrappers.host.Host(
+            host_pb2.Host(name=TEST_HOST_NAME))
+        host.setHardwareState(state)
+
+        stubMock.SetHardwareState.assert_called_with(
+            host_pb2.HostSetHardwareStateRequest(host=host.data, state=state),
+            timeout=mock.ANY)
+
+    def testSetOs(self, getStubMock):
+        stubMock = mock.Mock()
+        stubMock.SetOs.return_value = host_pb2.HostSetOsResponse()
+        getStubMock.return_value = stubMock
+
+        osName = 'linux'
+        host = opencue.wrappers.host.Host(
+            host_pb2.Host(name=TEST_HOST_NAME))
+        host.setOs(osName)
+
+        stubMock.SetOs.assert_called_with(
+            host_pb2.HostSetOsRequest(host=host.data, os=osName),
+            timeout=mock.ANY)
+
+    def testSetThreadMode(self, getStubMock):
+        stubMock = mock.Mock()
+        stubMock.SetThreadMode.return_value = host_pb2.HostSetThreadModeResponse()
+        getStubMock.return_value = stubMock
+
+        mode = host_pb2.VARIABLE
+        host = opencue.wrappers.host.Host(
+            host_pb2.Host(name=TEST_HOST_NAME))
+        host.setThreadMode(mode)
+
+        stubMock.SetThreadMode.assert_called_with(
+            host_pb2.HostSetThreadModeRequest(host=host.data, mode=mode),
+            timeout=mock.ANY)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Adding unittests for group and host wrappers.
NestedGroup asGroup function now returns a Group wrapper object.
Correctly labeling allocation id as id in Host SetAllocation call.