### PR TITLE
 Add CueGUI help constants

### DIFF
--- a/cuegui/cuegui/Constants.py
+++ b/cuegui/cuegui/Constants.py
@@ -65,8 +65,8 @@ EMAIL_BODY_SUFFIX = "\n\n"
 EMAIL_DOMAIN = ""
 
 URL_USERGUIDE = "https://opencue.io/docs/"
-URL_SUGGESTION = "https://github.com/imageworks/OpenCue/issues/new?assignees=&labels=enhancement&template=feature_request.md&title="
-URL_BUG = "https://github.com/imageworks/OpenCue/issues/new?assignees=&labels=bug&template=bug_report.md&title="
+URL_SUGGESTION = "https://github.com/imageworks/OpenCue/issues/new?labels=enhancement&template=feature_request.md"
+URL_BUG = "https://github.com/imageworks/OpenCue/issues/new?labels=bug&template=bug_report.md"
 
 DEFAULT_EDITOR = "gview -R -m -M -U %s/gvimrc +" % DEFAULT_INI_PATH
 

--- a/cuegui/cuegui/Constants.py
+++ b/cuegui/cuegui/Constants.py
@@ -64,9 +64,9 @@ EMAIL_BODY_PREFIX = "Your PSTs request that you check "
 EMAIL_BODY_SUFFIX = "\n\n"
 EMAIL_DOMAIN = ""
 
-URL_USERGUIDE = ""
-URL_SUGGESTION = ""
-URL_BUG = ""
+URL_USERGUIDE = "https://opencue.io/docs/"
+URL_SUGGESTION = "https://github.com/imageworks/OpenCue/issues/new?assignees=&labels=enhancement&template=feature_request.md&title="
+URL_BUG = "https://github.com/imageworks/OpenCue/issues/new?assignees=&labels=bug&template=bug_report.md&title="
 
 DEFAULT_EDITOR = "gview -R -m -M -U %s/gvimrc +" % DEFAULT_INI_PATH
 


### PR DESCRIPTION
Add CueGUI constants to address https://github.com/imageworks/OpenCue/issues/309

We'll need to update `URL_SUGGESTION` and `URL_BUG` if the repo URL changes.