### PR TITLE
Fix CueGui progress bar colors

### DIFF
--- a/cuegui/cuegui/CueJobMonitorTree.py
+++ b/cuegui/cuegui/CueJobMonitorTree.py
@@ -729,16 +729,17 @@ class JobWidgetItem(cuegui.AbstractWidgetItem.AbstractWidgetItem):
 
         elif role == QtCore.Qt.UserRole + 1:
             if "FST" not in self._cache:
-                self._cache["FST"] = set([
-                    ('WAITING', self.rpcObject.data.job_stats.waiting_frames),
-                    ('RUNNING', self.rpcObject.data.job_stats.running_frames),
-                    ('SUCCEEDED', self.rpcObject.data.job_stats.succeeded_frames),
-                    ('CHECKPOINT', 0),
-                    ('SETUP', 0),
-                    ('EATEN', self.rpcObject.data.job_stats.eaten_frames),
-                    ('DEAD', self.rpcObject.data.job_stats.dead_frames),
-                    ('DEPEND', self.rpcObject.data.job_stats.depend_frames)
-                ])
+                jobStats = self.rpcObject.data.job_stats
+                self._cache["FST"] = {
+                    opencue.compiled_proto.job_pb2.WAITING: jobStats.waiting_frames,
+                    opencue.compiled_proto.job_pb2.RUNNING: jobStats.running_frames,
+                    opencue.compiled_proto.job_pb2.SUCCEEDED: jobStats.succeeded_frames,
+                    opencue.compiled_proto.job_pb2.CHECKPOINT: 0,
+                    opencue.compiled_proto.job_pb2.SETUP: 0,
+                    opencue.compiled_proto.job_pb2.EATEN: jobStats.eaten_frames,
+                    opencue.compiled_proto.job_pb2.DEAD: jobStats.dead_frames,
+                    opencue.compiled_proto.job_pb2.DEPEND: jobStats.depend_frames,
+                }
             return self._cache.get("FST", cuegui.Constants.QVARIANT_NULL)
 
         return cuegui.Constants.QVARIANT_NULL

--- a/cuegui/cuegui/ItemDelegate.py
+++ b/cuegui/cuegui/ItemDelegate.py
@@ -97,9 +97,9 @@ class AbstractDelegate(QtWidgets.QItemDelegate):
         @param rect: The area to draw in
         @type  frameStateTotals: dict
         @param frameStateTotals: Dictionary of frame states and their amount"""
-        ratio = rect.width() / float(sum([list(values)[1] for values in frameStateTotals]))
+        ratio = rect.width() / float(sum(frameStateTotals.values()))
         for frameState in FRAME_STATES:
-            length = int(ceil(ratio * list(frameStateTotals)[frameState][1]))
+            length = int(ceil(ratio * frameStateTotals[frameState]))
             if length > 0:
                 rect.setWidth(length)
                 painter.fillRect(rect, RGB_FRAME_STATE[frameState])

--- a/pycue/opencue/wrappers/job.py
+++ b/pycue/opencue/wrappers/job.py
@@ -537,9 +537,10 @@ class Job(object):
         @rtype: dict
         @return: total number of frames in each state"""
         if not hasattr(self, "__frameStateTotals"):
-            self.__frameStateTotals = {
-                (a, getattr(self.data.job_stats, "%s_frames" % a.lower(), 0))
-                for a in job_pb2.FrameState.keys()}
+            self.__frameStateTotals = {}
+            for state in job_pb2.FrameState.keys():
+                frameCount = getattr(self.data.job_stats, '{}_frames'.format(state.lower()), 0)
+                self.__frameStateTotals[getattr(job_pb2, state)] = frameCount
         return self.__frameStateTotals
 
     def percentCompleted(self):

--- a/pycue/tests/wrappers/job_test.py
+++ b/pycue/tests/wrappers/job_test.py
@@ -459,6 +459,30 @@ class JobTests(unittest.TestCase):
             job_pb2.JobStaggerFramesRequest(job=job.data, range=range, stagger=stagger),
             timeout=mock.ANY)
 
+    def testFrameStateTotals(self, getStubMock):
+        runningFrames = 10
+        waitingFrames = 50
+        succeededFrames = 30
+        expected = {job_pb2.WAITING: waitingFrames,
+                    job_pb2.RUNNING: runningFrames,
+                    job_pb2.SUCCEEDED: succeededFrames,
+                    job_pb2.CHECKPOINT: 0,
+                    job_pb2.SETUP: 0,
+                    job_pb2.EATEN: 0,
+                    job_pb2.DEAD: 0,
+                    job_pb2.DEPEND: 0}
+
+        job = opencue.wrappers.job.Job(job_pb2.Job(
+            name="frameStateTestJob",
+            job_stats=job_pb2.JobStats(
+                running_frames=runningFrames,
+                waiting_frames=waitingFrames,
+                succeeded_frames=succeededFrames)))
+
+        frameStateTotals = job.frameStateTotals()
+        self.assertEqual(frameStateTotals, expected)
+
+
 @mock.patch('opencue.cuebot.Cuebot.getStub')
 class NestedJobTests(unittest.TestCase):
 


### PR DESCRIPTION
The progress bar colors in CueGui were essentially random due to reliance on the order of a set.  This change uses a dictionary instead of a set to store the frame states and fixes the color lookup.

Fixes #327. Make frameStateTotals return a dictionary so order does not matter.